### PR TITLE
Events

### DIFF
--- a/src/main/java/org/openhds/events/endpoint/EventEndpoint.java
+++ b/src/main/java/org/openhds/events/endpoint/EventEndpoint.java
@@ -1,0 +1,8 @@
+package org.openhds.events.endpoint;
+
+import org.openhds.events.model.Event;
+
+public interface EventEndpoint {
+
+    void publishEvent(Event event);
+}

--- a/src/main/java/org/openhds/events/endpoint/impl/DatabaseEventEndpoint.java
+++ b/src/main/java/org/openhds/events/endpoint/impl/DatabaseEventEndpoint.java
@@ -1,0 +1,19 @@
+package org.openhds.events.endpoint.impl;
+
+import org.openhds.events.endpoint.EventEndpoint;
+import org.openhds.events.model.Event;
+import org.openhds.repository.concrete.EventRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseEventEndpoint implements EventEndpoint {
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Override
+    public void publishEvent(Event event) {
+        eventRepository.save(event);
+    }
+}

--- a/src/main/java/org/openhds/events/model/Event.java
+++ b/src/main/java/org/openhds/events/model/Event.java
@@ -75,9 +75,9 @@ public class Event extends AuditableEntity implements Serializable {
             return null;
         }
 
-        for (EventMetadata medadata : eventMetadata) {
-            if (medadata.getSystem().equals(system)) {
-                return medadata;
+        for (EventMetadata metadata : eventMetadata) {
+            if (metadata.getSystem().equals(system)) {
+                return metadata;
             }
         }
 

--- a/src/main/java/org/openhds/events/model/Event.java
+++ b/src/main/java/org/openhds/events/model/Event.java
@@ -14,6 +14,10 @@ import java.util.List;
 @Table(name = "events")
 public class Event extends AuditableEntity implements Serializable {
 
+    public static final String DEFAULT_SYSTEM = "default";
+    public static final String DEFAULT_STATUS = "unread";
+    public static final String READ_STATUS = "read";
+
     private String actionType;
 
     private String entityType;

--- a/src/main/java/org/openhds/events/model/Event.java
+++ b/src/main/java/org/openhds/events/model/Event.java
@@ -1,0 +1,86 @@
+package org.openhds.events.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.openhds.domain.contract.AuditableEntity;
+import org.openhds.domain.util.Description;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Description(description = "Collection of atomic OpenHDS system events")
+@Entity
+@Table(name = "events")
+public class Event extends AuditableEntity implements Serializable {
+
+    private String actionType;
+
+    private String entityType;
+
+    @Column(length=65535)
+    private String eventData;
+
+    private static final long serialVersionUID = 1L;
+
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, targetEntity = EventMetadata.class)
+    @JoinColumn(name = "event_uuid")
+    @JsonIgnore
+    private List<EventMetadata> eventMetadata = new ArrayList<>();
+
+    public Event() { }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getActionType() {
+        return actionType;
+    }
+
+    public void setActionType(String actionType) {
+        this.actionType = actionType;
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    public void setEntityType(String entityType) {
+        this.entityType = entityType;
+    }
+
+    public String getEventData() {
+        return eventData;
+    }
+
+    public void setEventData(String eventData) {
+        this.eventData = eventData;
+    }
+
+    public List<EventMetadata> getEventMetadata() {
+        return eventMetadata;
+    }
+
+    public void setEventMetadata(List<EventMetadata> eventMetadata) {
+        this.eventMetadata = eventMetadata;
+    }
+
+    public EventMetadata findMetadataForSystem(String system) {
+        if (null == eventMetadata) {
+            return null;
+        }
+
+        for (EventMetadata medadata : eventMetadata) {
+            if (medadata.getSystem().equals(system)) {
+                return medadata;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/openhds/events/model/Event.java
+++ b/src/main/java/org/openhds/events/model/Event.java
@@ -5,6 +5,7 @@ import org.openhds.domain.contract.AuditableEntity;
 import org.openhds.domain.util.Description;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,12 +15,16 @@ import java.util.List;
 @Table(name = "events")
 public class Event extends AuditableEntity implements Serializable {
 
-    public static final String DEFAULT_SYSTEM = "default";
+    public static final String DEFAULT_ACTION = "default-action";
+    public static final String DEFAULT_ENTITY = "default-entity";
+    public static final String DEFAULT_SYSTEM = "default-system";
     public static final String DEFAULT_STATUS = "unread";
     public static final String READ_STATUS = "read";
 
+    @NotNull
     private String actionType;
 
+    @NotNull
     private String entityType;
 
     @Column(length=65535)
@@ -29,7 +34,6 @@ public class Event extends AuditableEntity implements Serializable {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, targetEntity = EventMetadata.class)
     @JoinColumn(name = "event_uuid")
-    @JsonIgnore
     private List<EventMetadata> eventMetadata = new ArrayList<>();
 
     public Event() { }

--- a/src/main/java/org/openhds/events/model/EventMetadata.java
+++ b/src/main/java/org/openhds/events/model/EventMetadata.java
@@ -5,6 +5,7 @@ import org.openhds.domain.util.Description;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
 @Description(description = "Metadata regarding an atomic event in OpenHDS")
 @Entity
@@ -13,11 +14,11 @@ public class EventMetadata extends AuditableEntity {
 
     private static final long serialVersionUID = 1L;
 
+    @NotNull
     private String status;
 
+    @NotNull
     private String system;
-
-    private String result;
 
     private int numTimesRead;
 
@@ -35,14 +36,6 @@ public class EventMetadata extends AuditableEntity {
 
     public void setSystem(String system) {
         this.system = system;
-    }
-
-    public String getResult() {
-        return result;
-    }
-
-    public void setResult(String result) {
-        this.result = result;
     }
 
     public int getNumTimesRead() {

--- a/src/main/java/org/openhds/events/model/EventMetadata.java
+++ b/src/main/java/org/openhds/events/model/EventMetadata.java
@@ -1,0 +1,55 @@
+package org.openhds.events.model;
+
+import org.openhds.domain.contract.AuditableEntity;
+import org.openhds.domain.util.Description;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Description(description = "Metadata regarding an atomic event in OpenHDS")
+@Entity
+@Table(name = "eventmetadata")
+public class EventMetadata extends AuditableEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    private String status;
+
+    private String system;
+
+    private String result;
+
+    private int numTimesRead;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getSystem() {
+        return system;
+    }
+
+    public void setSystem(String system) {
+        this.system = system;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(String result) {
+        this.result = result;
+    }
+
+    public int getNumTimesRead() {
+        return numTimesRead;
+    }
+
+    public void setNumTimesRead(int numTimesRead) {
+        this.numTimesRead = numTimesRead;
+    }
+}

--- a/src/main/java/org/openhds/events/queries/EventSpecifications.java
+++ b/src/main/java/org/openhds/events/queries/EventSpecifications.java
@@ -14,8 +14,26 @@ import javax.persistence.criteria.*;
  */
 public class EventSpecifications {
 
-    // Query events by actionType, entityType, date range, system, and status
-    public static <R extends Comparable> Specification<Event> multiValueRangedBySystemAndStatus(
+    // Query events by properties and date range, never queries by given system.
+    public static <R extends Comparable> Specification<Event> multiValueRangedWithoutSystem (
+            final QueryRange<R> queryRange,
+            final QueryValue[] queryValues,
+            final String system) {
+
+        return new Specification<Event>() {
+            @Override
+            public Predicate toPredicate(Root<Event> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+                query.distinct(true);
+                return cb.and(
+                        Specifications.allValuesEqual(root, cb, queryValues),
+                        Specifications.inRange(root, cb, queryRange),
+                        noExistingMetadataForSystem(root, query, cb, system));
+            }
+        };
+    }
+
+    // Query events by properties and date range, never queries by given system.
+    public static <R extends Comparable> Specification<Event> multiValueRangedMatchingValues(
             final QueryRange<R> queryRange,
             final QueryValue[] queryValues,
             final QueryValue[] metadataQueryValues) {
@@ -24,11 +42,25 @@ public class EventSpecifications {
             @Override
             public Predicate toPredicate(Root<Event> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
                 query.distinct(true);
-                return cb.and(Specifications.allValuesEqual(root, cb, queryValues),
+                return cb.and(
+                        Specifications.allValuesEqual(root, cb, queryValues),
                         Specifications.inRange(root, cb, queryRange),
                         existingMetadataAllValuesEqual(root, query, cb, metadataQueryValues));
             }
         };
+    }
+
+    public static Predicate noExistingMetadataForSystem(Root<Event> root,
+                                                        CriteriaQuery<?> query,
+                                                        CriteriaBuilder cb,
+                                                        String system) {
+
+        Join<Event, EventMetadata> metadataJoin = root.join("eventMetadata");
+        Subquery<EventMetadata> subquery = query.subquery(EventMetadata.class);
+        subquery.from(EventMetadata.class);
+        subquery.select(metadataJoin);
+        subquery.where(cb.equal(metadataJoin.get("system"), system));
+        return cb.not(cb.exists(subquery));
     }
 
     public static Predicate existingMetadataAllValuesEqual(Root<Event> root,

--- a/src/main/java/org/openhds/events/queries/EventSpecifications.java
+++ b/src/main/java/org/openhds/events/queries/EventSpecifications.java
@@ -1,0 +1,56 @@
+package org.openhds.events.queries;
+
+import org.openhds.events.model.Event;
+import org.openhds.events.model.EventMetadata;
+import org.openhds.repository.queries.QueryRange;
+import org.openhds.repository.queries.QueryValue;
+import org.openhds.repository.queries.Specifications;
+import org.springframework.data.jpa.domain.Specification;
+
+import javax.persistence.criteria.*;
+
+/**
+ * Created by bsh on 6/30/15.
+ */
+public class EventSpecifications {
+
+    // Query events by actionType, entityType, date range, system, and status
+    public static <R extends Comparable> Specification<Event> multiValueRangedBySystemAndStatus(
+            final String system,
+            final String status,
+            final QueryRange<R> queryRange,
+            final QueryValue... queryValues) {
+
+        return new Specification<Event>() {
+            @Override
+            public Predicate toPredicate(Root<Event> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
+                Join<Event, EventMetadata> metadataJoin = root.join("eventMetadata");
+                return cb.and(Specifications.allValuesEqualOrNull(root, cb, queryValues),
+                        Specifications.inRangeOrNull(root, cb, queryRange),
+                        cb.or(noEventMetadataForSystem(metadataJoin, query, cb, system),
+                                eventMetadataForSystemWithStatus(metadataJoin, query, cb, system, status)));
+            }
+        };
+    }
+
+    public static Predicate noEventMetadataForSystem(Join<Event, EventMetadata> metadataJoin,
+                                                     CriteriaQuery<?> query,
+                                                     CriteriaBuilder cb,
+                                                     String system) {
+        Subquery<EventMetadata> subquery = query.subquery(EventMetadata.class);
+        subquery.where(cb.equal(metadataJoin.get("system"), system));
+        return cb.exists(subquery).not();
+    }
+
+    public static Predicate eventMetadataForSystemWithStatus(Join<Event, EventMetadata> metadataJoin,
+                                                             CriteriaQuery<?> query,
+                                                             CriteriaBuilder cb,
+                                                             String system,
+                                                             String status) {
+        Subquery<EventMetadata> subquery = query.subquery(EventMetadata.class);
+        subquery.where(cb.and(cb.equal(metadataJoin.get("system"), system),
+                cb.equal(metadataJoin.get("status"), status)));
+        return cb.exists(subquery);
+    }
+
+}

--- a/src/main/java/org/openhds/repository/concrete/EventMetadataRepository.java
+++ b/src/main/java/org/openhds/repository/concrete/EventMetadataRepository.java
@@ -1,0 +1,12 @@
+package org.openhds.repository.concrete;
+
+/**
+ * Created by Ben on 5/4/15.
+ */
+
+import org.openhds.domain.model.LocationHierarchy;
+import org.openhds.events.model.EventMetadata;
+import org.openhds.repository.contract.AuditableRepository;
+
+public interface EventMetadataRepository extends AuditableRepository<EventMetadata> {
+}

--- a/src/main/java/org/openhds/repository/concrete/EventRepository.java
+++ b/src/main/java/org/openhds/repository/concrete/EventRepository.java
@@ -1,0 +1,12 @@
+package org.openhds.repository.concrete;
+
+/**
+ * Created by Ben on 5/4/15.
+ */
+
+import org.openhds.domain.model.LocationHierarchy;
+import org.openhds.events.model.Event;
+import org.openhds.repository.contract.AuditableRepository;
+
+public interface EventRepository extends AuditableRepository<Event> {
+}

--- a/src/main/java/org/openhds/repository/concrete/EventRepository.java
+++ b/src/main/java/org/openhds/repository/concrete/EventRepository.java
@@ -4,7 +4,6 @@ package org.openhds.repository.concrete;
  * Created by Ben on 5/4/15.
  */
 
-import org.openhds.domain.model.LocationHierarchy;
 import org.openhds.events.model.Event;
 import org.openhds.repository.contract.AuditableRepository;
 

--- a/src/main/java/org/openhds/repository/queries/Specifications.java
+++ b/src/main/java/org/openhds/repository/queries/Specifications.java
@@ -3,10 +3,7 @@ package org.openhds.repository.queries;
 import org.openhds.domain.contract.UuidIdentifiable;
 import org.springframework.data.jpa.domain.Specification;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import javax.persistence.criteria.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,14 +35,30 @@ public class Specifications {
         };
     }
 
-    private static <R extends java.lang.Comparable> Predicate inRange(Root<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
+    public static <R extends java.lang.Comparable> Predicate inRange(Root<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
         return cb.between(root.<R>get(queryRange.getPropertyName()), queryRange.getMin(), queryRange.getMax());
     }
 
-    private static Predicate allValuesEqual(Root<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
+    public static <R extends java.lang.Comparable> Predicate inRangeOrNull(Root<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
+        Path<R> path = root.<R>get(queryRange.getPropertyName());
+        return cb.or(cb.isNull(path),
+                cb.between(path, queryRange.getMin(), queryRange.getMax()));
+    }
+
+    public static Predicate allValuesEqual(Root<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
         List<Predicate> predicates = new ArrayList<>();
         for (QueryValue queryValue : queryValues) {
             predicates.add(cb.equal(root.get(queryValue.getPropertyName()), queryValue.getValue()));
+        }
+        return cb.and(predicates.toArray(new Predicate[predicates.size()]));
+    }
+
+    public static Predicate allValuesEqualOrNull(Root<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
+        List<Predicate> predicates = new ArrayList<>();
+        for (QueryValue queryValue : queryValues) {
+            Path<?> path = root.get(queryValue.getPropertyName());
+            predicates.add(cb.or(cb.isNull(path),
+                    cb.equal(path, queryValue.getValue())));
         }
         return cb.and(predicates.toArray(new Predicate[predicates.size()]));
     }

--- a/src/main/java/org/openhds/repository/queries/Specifications.java
+++ b/src/main/java/org/openhds/repository/queries/Specifications.java
@@ -35,17 +35,17 @@ public class Specifications {
         };
     }
 
-    public static <R extends java.lang.Comparable> Predicate inRange(Root<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
+    public static <R extends java.lang.Comparable> Predicate inRange(Path<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
         return cb.between(root.<R>get(queryRange.getPropertyName()), queryRange.getMin(), queryRange.getMax());
     }
 
-    public static <R extends java.lang.Comparable> Predicate inRangeOrNull(Root<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
+    public static <R extends java.lang.Comparable> Predicate inRangeOrNull(Path<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
         Path<R> path = root.<R>get(queryRange.getPropertyName());
         return cb.or(cb.isNull(path),
                 cb.between(path, queryRange.getMin(), queryRange.getMax()));
     }
 
-    public static Predicate allValuesEqual(Root<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
+    public static Predicate allValuesEqual(Path<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
         List<Predicate> predicates = new ArrayList<>();
         for (QueryValue queryValue : queryValues) {
             predicates.add(cb.equal(root.get(queryValue.getPropertyName()), queryValue.getValue()));
@@ -53,7 +53,7 @@ public class Specifications {
         return cb.and(predicates.toArray(new Predicate[predicates.size()]));
     }
 
-    public static Predicate allValuesEqualOrNull(Root<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
+    public static Predicate allValuesEqualOrNull(Path<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
         List<Predicate> predicates = new ArrayList<>();
         for (QueryValue queryValue : queryValues) {
             Path<?> path = root.get(queryValue.getPropertyName());

--- a/src/main/java/org/openhds/repository/queries/Specifications.java
+++ b/src/main/java/org/openhds/repository/queries/Specifications.java
@@ -39,12 +39,6 @@ public class Specifications {
         return cb.between(root.<R>get(queryRange.getPropertyName()), queryRange.getMin(), queryRange.getMax());
     }
 
-    public static <R extends java.lang.Comparable> Predicate inRangeOrNull(Path<?> root, CriteriaBuilder cb, QueryRange<R> queryRange) {
-        Path<R> path = root.<R>get(queryRange.getPropertyName());
-        return cb.or(cb.isNull(path),
-                cb.between(path, queryRange.getMin(), queryRange.getMax()));
-    }
-
     public static Predicate allValuesEqual(Path<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
         List<Predicate> predicates = new ArrayList<>();
         for (QueryValue queryValue : queryValues) {
@@ -52,15 +46,4 @@ public class Specifications {
         }
         return cb.and(predicates.toArray(new Predicate[predicates.size()]));
     }
-
-    public static Predicate allValuesEqualOrNull(Path<?> root, CriteriaBuilder cb, QueryValue... queryValues) {
-        List<Predicate> predicates = new ArrayList<>();
-        for (QueryValue queryValue : queryValues) {
-            Path<?> path = root.get(queryValue.getPropertyName());
-            predicates.add(cb.or(cb.isNull(path),
-                    cb.equal(path, queryValue.getValue())));
-        }
-        return cb.and(predicates.toArray(new Predicate[predicates.size()]));
-    }
-
 }

--- a/src/main/java/org/openhds/repository/results/ShallowCopyIterator.java
+++ b/src/main/java/org/openhds/repository/results/ShallowCopyIterator.java
@@ -3,59 +3,19 @@ package org.openhds.repository.results;
 import org.openhds.domain.contract.UuidIdentifiable;
 import org.openhds.domain.util.ShallowCopier;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 /**
  * Created by Ben on 6/23/15.
  *
  * Wrap an existing EntityIterator and convert the results to shallow copies.
  *
  */
-public class ShallowCopyIterator<T extends UuidIdentifiable> implements EntityIterator<T>, Iterator<T> {
-
-    private final EntityIterator<T> original;
+public class ShallowCopyIterator<T extends UuidIdentifiable> extends UpdatingIterator<T> {
 
     public ShallowCopyIterator(EntityIterator<T> original) {
-        this.original = original;
+        super(original, ShallowCopyIterator::shallowCopy);
     }
 
-    @Override
-    public List<T> toList() {
-        List<T> list = new ArrayList<>();
-        for (T entity : original) {
-            list.add(shallowCopy(entity));
-        }
-        return list;
-    }
-
-    @Override
-    public String getCollectionName() {
-        return original.getCollectionName();
-    }
-
-    @Override
-    public void setCollectionName(String collectionName) {
-        original.setCollectionName(collectionName);
-    }
-
-    @Override
-    public Iterator<T> iterator() {
-        return this;
-    }
-
-    @Override
-    public boolean hasNext() {
-        return original.iterator().hasNext();
-    }
-
-    @Override
-    public T next() {
-        return shallowCopy(original.iterator().next());
-    }
-
-    private T shallowCopy(T entity) {
+    private static <T extends UuidIdentifiable> T shallowCopy(T entity) {
         return ShallowCopier.makeShallowCopy(entity, null);
     }
 }

--- a/src/main/java/org/openhds/repository/results/UpdatingIterator.java
+++ b/src/main/java/org/openhds/repository/results/UpdatingIterator.java
@@ -1,0 +1,64 @@
+package org.openhds.repository.results;
+
+import org.openhds.domain.contract.UuidIdentifiable;
+import org.openhds.domain.util.ShallowCopier;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Created by Ben on 6/23/15.
+ *
+ * Wrap an existing EntityIterator and invoke an update callback for each next().
+ *
+ */
+public class UpdatingIterator<T extends UuidIdentifiable> implements EntityIterator<T>, Iterator<T> {
+
+    public interface Updater<T> {
+        T update(T entity);
+    }
+
+    private final EntityIterator<T> original;
+
+    private final Updater<T> updater;
+
+    public UpdatingIterator(EntityIterator<T> original, Updater<T> updater) {
+        this.original = original;
+        this.updater = updater;
+    }
+
+    @Override
+    public List<T> toList() {
+        List<T> list = new ArrayList<>();
+        for (T entity : original) {
+            list.add(updater.update(entity));
+        }
+        return list;
+    }
+
+    @Override
+    public String getCollectionName() {
+        return original.getCollectionName();
+    }
+
+    @Override
+    public void setCollectionName(String collectionName) {
+        original.setCollectionName(collectionName);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return this;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return original.iterator().hasNext();
+    }
+
+    @Override
+    public T next() {
+        return updater.update(original.iterator().next());
+    }
+}

--- a/src/main/java/org/openhds/repository/util/QueryUtil.java
+++ b/src/main/java/org/openhds/repository/util/QueryUtil.java
@@ -1,0 +1,28 @@
+package org.openhds.repository.util;
+
+import org.openhds.repository.queries.QueryRange;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Created by bsh on 7/1/15.
+ */
+public class QueryUtil {
+
+    public static QueryRange<ZonedDateTime> dateQueryRange(String propertyName, ZonedDateTime minDate, ZonedDateTime maxDate) {
+        // default to errors up until now
+        ZonedDateTime rangeMax = ZonedDateTime.now();
+        if (maxDate != null) {
+            rangeMax = maxDate;
+        }
+
+        // default to date range of one week
+        ZonedDateTime rangeMin = rangeMax.minusDays(7);
+        if (minDate != null) {
+            rangeMin = minDate;
+        }
+
+        return new QueryRange<>(propertyName, rangeMin, rangeMax);
+    }
+
+}

--- a/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
+++ b/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
@@ -8,6 +8,7 @@ import org.openhds.domain.model.LocationHierarchy;
 import org.openhds.domain.model.LocationHierarchyLevel;
 import org.openhds.errors.model.ErrorLog;
 import org.openhds.errors.model.Error;
+import org.openhds.events.model.Event;
 import org.openhds.events.model.EventMetadata;
 import org.openhds.repository.concrete.*;
 import org.openhds.security.model.Privilege;
@@ -108,6 +109,8 @@ public class SampleDataGenerator {
         addLocation("duplicated", "bottom-two");
 
         addErrorLog("sample error");
+
+        addEvent("sample event", "sample system");
     }
 
     private void addPrivileges(Privilege.Grant... grants) {
@@ -210,5 +213,18 @@ public class SampleDataGenerator {
         errorLog.getErrors().add(error);
 
         errorLogRepository.save(errorLog);
+    }
+
+    private void addEvent(String description, String system) {
+        Event event = new Event();
+        initAuditableFields(event);
+        event.setEventData(description);
+
+        EventMetadata eventMetadata = new EventMetadata();
+        initAuditableFields(eventMetadata);
+        eventMetadata.setSystem(system);
+        event.getEventMetadata().add(eventMetadata);
+
+        eventRepository.save(event);
     }
 }

--- a/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
+++ b/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
@@ -6,8 +6,8 @@ import org.openhds.domain.model.FieldWorker;
 import org.openhds.domain.model.Location;
 import org.openhds.domain.model.LocationHierarchy;
 import org.openhds.domain.model.LocationHierarchyLevel;
-import org.openhds.errors.model.ErrorLog;
 import org.openhds.errors.model.Error;
+import org.openhds.errors.model.ErrorLog;
 import org.openhds.events.model.Event;
 import org.openhds.events.model.EventMetadata;
 import org.openhds.repository.concrete.*;
@@ -218,12 +218,15 @@ public class SampleDataGenerator {
     private void addEvent(String description, String system) {
         Event event = new Event();
         initAuditableFields(event);
+
+        event.setActionType(Event.DEFAULT_ACTION);
+        event.setEntityType(Event.DEFAULT_ENTITY);
         event.setEventData(description);
 
-        EventMetadata eventMetadata = new EventMetadata();
-        initAuditableFields(eventMetadata);
-        eventMetadata.setSystem(system);
-        event.getEventMetadata().add(eventMetadata);
+        EventMetadata defaultMetadata = new EventMetadata();
+        defaultMetadata.setSystem(Event.DEFAULT_SYSTEM);
+        defaultMetadata.setStatus(Event.DEFAULT_STATUS);
+        event.getEventMetadata().add(defaultMetadata);
 
         eventRepository.save(event);
     }

--- a/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
+++ b/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
@@ -8,6 +8,7 @@ import org.openhds.domain.model.LocationHierarchy;
 import org.openhds.domain.model.LocationHierarchyLevel;
 import org.openhds.errors.model.ErrorLog;
 import org.openhds.errors.model.Error;
+import org.openhds.events.model.EventMetadata;
 import org.openhds.repository.concrete.*;
 import org.openhds.security.model.Privilege;
 import org.openhds.security.model.Role;
@@ -56,7 +57,16 @@ public class SampleDataGenerator {
     @Autowired
     private ErrorLogRepository errorLogRepository;
 
+    @Autowired
+    private EventMetadataRepository eventMetadataRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
     public void clearData() {
+        eventMetadataRepository.deleteAllInBatch();
+        eventRepository.deleteAllInBatch();
+
         errorRepository.deleteAllInBatch();
         errorLogRepository.deleteAllInBatch();
 

--- a/src/main/java/org/openhds/resource/contract/AuditableRestController.java
+++ b/src/main/java/org/openhds/resource/contract/AuditableRestController.java
@@ -60,7 +60,8 @@ public abstract class AuditableRestController<T extends AuditableEntity, U exten
 
     // afterDate <= lastModifiedDate < beforeDate
     @RequestMapping(value = "/bydate", method = RequestMethod.GET)
-    public PagedResources readByDatePaged(Pageable pageable, PagedResourcesAssembler assembler,
+    public PagedResources readByDatePaged(Pageable pageable,
+                                          PagedResourcesAssembler assembler,
                                           @RequestParam(required = false)
                                           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
                                           ZonedDateTime afterDate,

--- a/src/main/java/org/openhds/resource/controller/EventRestController.java
+++ b/src/main/java/org/openhds/resource/controller/EventRestController.java
@@ -1,19 +1,31 @@
 package org.openhds.resource.controller;
 
-import org.openhds.errors.model.ErrorLog;
 import org.openhds.events.model.Event;
 import org.openhds.repository.concrete.EventRepository;
 import org.openhds.repository.concrete.UserRepository;
+import org.openhds.repository.queries.QueryRange;
+import org.openhds.repository.queries.QueryValue;
+import org.openhds.repository.results.EntityIterator;
+import org.openhds.repository.results.UpdatingIterator;
 import org.openhds.resource.contract.AuditableRestController;
 import org.openhds.resource.registration.EventRegistration;
 import org.openhds.service.impl.EventService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.ConstraintViolationException;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.openhds.repository.util.QueryUtil.dateQueryRange;
 
 /**
  * Created by bsh on 6/30/15.
@@ -59,4 +71,40 @@ public class EventRestController extends AuditableRestController<Event, EventReg
         registration.getEvent().setUuid(id);
         return register(registration);
     }
+
+    @RequestMapping(value = "query", method = RequestMethod.GET)
+    public EntityIterator<Event> findEvents(@RequestParam(value="system", required=false) String system,
+                                            @RequestParam(value="status", required=false) String status,
+                                            @RequestParam(value="actionType", required=false) String actionType,
+                                            @RequestParam(value="entityType", required=false) String entityType,
+                                            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                            @RequestParam(value = "minDate", required = false) ZonedDateTime minDate,
+                                            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                            @RequestParam(value = "maxDate", required = false) ZonedDateTime maxDate) {
+
+        List<QueryValue> properties = new ArrayList<>();
+        addIfPresent(properties, "system", system, Event.DEFAULT_SYSTEM);
+        addIfPresent(properties, "status", status, Event.DEFAULT_STATUS);
+        addIfPresent(properties, "actionType", actionType, null);
+        addIfPresent(properties, "entityType", entityType, null);
+
+        QueryRange<ZonedDateTime> dateRange = dateQueryRange("lastModifiedDate", minDate, maxDate);
+
+        EntityIterator<Event> events = eventService.findByMultipleValuesRanged(
+                new Sort("lastModifiedDate"),
+                dateRange,
+                properties.toArray(new QueryValue[properties.size()]));
+
+        // increment read counts as each event goes out the wire
+        return new UpdatingIterator<>(events, (event) -> eventService.incrementReadCount(event, system));
+    }
+
+    private static void addIfPresent(Collection<QueryValue> properties, String propertyName, String value, String defaultValue) {
+        if (value != null && !value.trim().isEmpty()) {
+            properties.add(new QueryValue(propertyName, value));
+        } else if (null != defaultValue) {
+            properties.add(new QueryValue(propertyName, defaultValue));
+        }
+    }
+
 }

--- a/src/main/java/org/openhds/resource/controller/EventRestController.java
+++ b/src/main/java/org/openhds/resource/controller/EventRestController.java
@@ -1,0 +1,62 @@
+package org.openhds.resource.controller;
+
+import org.openhds.errors.model.ErrorLog;
+import org.openhds.events.model.Event;
+import org.openhds.repository.concrete.EventRepository;
+import org.openhds.repository.concrete.UserRepository;
+import org.openhds.resource.contract.AuditableRestController;
+import org.openhds.resource.registration.EventRegistration;
+import org.openhds.service.impl.EventService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.ConstraintViolationException;
+import java.time.ZonedDateTime;
+
+/**
+ * Created by bsh on 6/30/15.
+ */
+@RestController
+@RequestMapping("/events")
+@ExposesResourceFor(Event.class)
+public class EventRestController extends AuditableRestController<Event, EventRegistration> {
+
+    private final EventService eventService;
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public EventRestController(EventRepository eventRepository,
+                               EventService eventService,
+                               UserRepository userRepository) {
+        super(eventRepository);
+        this.eventService = eventService;
+        this.userRepository = userRepository;
+    }
+
+
+    @Override
+    protected Event register(EventRegistration registration) {
+        Event event = registration.getEvent();
+
+        if (null == event.getEventData()) {
+            throw new ConstraintViolationException("Event data must not be null.", null);
+        }
+
+        // TODO: this looks like service stuff
+        event.setInsertBy(userRepository.findAll().get(0));
+        event.setLastModifiedBy(userRepository.findAll().get(0));
+        event.setInsertDate(ZonedDateTime.now());
+        event.setLastModifiedDate(ZonedDateTime.now());
+
+        return eventService.createOrUpdate(event);
+    }
+
+    @Override
+    protected Event register(EventRegistration registration, String id) {
+        registration.getEvent().setUuid(id);
+        return register(registration);
+    }
+}

--- a/src/main/java/org/openhds/resource/registration/EventRegistration.java
+++ b/src/main/java/org/openhds/resource/registration/EventRegistration.java
@@ -1,0 +1,19 @@
+package org.openhds.resource.registration;
+
+import org.openhds.events.model.Event;
+
+/**
+ * Created by bsh on 6/29/15.
+ */
+public class EventRegistration extends Registration<Event> {
+
+    private Event event;
+
+    public Event getEvent() {
+        return event;
+    }
+
+    public void setEvent(Event event) {
+        this.event = event;
+    }
+}

--- a/src/main/java/org/openhds/service/impl/EventService.java
+++ b/src/main/java/org/openhds/service/impl/EventService.java
@@ -5,12 +5,14 @@ import org.openhds.events.model.Event;
 import org.openhds.repository.concrete.EventRepository;
 import org.openhds.service.contract.AbstractAuditableService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 /**
  * Created by bsh on 6/30/15.
  */
+@Component
 public class EventService extends AbstractAuditableService <Event, EventRepository> {
 
     @Autowired

--- a/src/main/java/org/openhds/service/impl/EventService.java
+++ b/src/main/java/org/openhds/service/impl/EventService.java
@@ -2,6 +2,7 @@ package org.openhds.service.impl;
 
 import org.openhds.events.endpoint.EventEndpoint;
 import org.openhds.events.model.Event;
+import org.openhds.events.model.EventMetadata;
 import org.openhds.repository.concrete.EventRepository;
 import org.openhds.service.contract.AbstractAuditableService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,34 @@ public class EventService extends AbstractAuditableService <Event, EventReposito
         for (EventEndpoint endpoint : eventEndpoints) {
             endpoint.publishEvent(event);
         }
+    }
+
+    public void incrementReadCount(Iterable<Event> events, String system) {
+        for (Event event : events) {
+            incrementReadCount(event, system);
+        }
+    }
+
+    public Event incrementReadCount(Event event, String system) {
+
+        if (null == system) {
+            system = Event.DEFAULT_SYSTEM;
+        }
+
+        EventMetadata md = event.findMetadataForSystem(system);
+        if (md == null) {
+            md = new EventMetadata();
+            md.setNumTimesRead(1);
+            md.setStatus(Event.READ_STATUS);
+            md.setSystem(system);
+            event.getEventMetadata().add(md);
+        } else {
+            md.setNumTimesRead(md.getNumTimesRead() + 1);
+            md.setStatus(Event.READ_STATUS);
+            md.setSystem(system);
+        }
+
+        return repository.save(event);
     }
 
 }

--- a/src/main/java/org/openhds/service/impl/EventService.java
+++ b/src/main/java/org/openhds/service/impl/EventService.java
@@ -3,11 +3,20 @@ package org.openhds.service.impl;
 import org.openhds.events.endpoint.EventEndpoint;
 import org.openhds.events.model.Event;
 import org.openhds.events.model.EventMetadata;
+import org.openhds.events.queries.EventSpecifications;
 import org.openhds.repository.concrete.EventRepository;
+import org.openhds.repository.queries.QueryRange;
+import org.openhds.repository.queries.QueryValue;
+import org.openhds.repository.results.EntityIterator;
 import org.openhds.service.contract.AbstractAuditableService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -29,35 +38,60 @@ public class EventService extends AbstractAuditableService <Event, EventReposito
         return new Event();
     }
 
+    public EntityIterator<Event> findBySystemAndStatus(Sort sort,
+                                                       QueryRange<ZonedDateTime> queryRange,
+                                                       QueryValue[] queryValues,
+                                                       QueryValue[] metadataQueryValues) {
+        Specification<Event> specification = EventSpecifications.multiValueRangedBySystemAndStatus(queryRange,
+                queryValues,
+                metadataQueryValues);
+        return iteratorFromPageable(pageable -> repository.findAll(specification, pageable), sort);
+    }
+
+    @Override
+    public Event createOrUpdate(Event entity) {
+        addDefaultMetadata(entity);
+        return super.createOrUpdate(entity);
+    }
+
+    private void addDefaultMetadata(Event entity) {
+        if (null == entity.findMetadataForSystem(Event.DEFAULT_SYSTEM)) {
+            EventMetadata defaultMetadata = new EventMetadata();
+            defaultMetadata.setSystem(Event.DEFAULT_SYSTEM);
+            defaultMetadata.setStatus(Event.DEFAULT_STATUS);
+            entity.getEventMetadata().add(defaultMetadata);
+        }
+    }
+
+    public Page<Event> findBySystemAndStatus(Pageable pageable,
+                                             QueryRange<ZonedDateTime> queryRange,
+                                             QueryValue[] queryValues,
+                                             QueryValue[] metadataQueryValues) {
+        Specification<Event> specification = EventSpecifications.multiValueRangedBySystemAndStatus(queryRange,
+                queryValues,
+                metadataQueryValues);
+        return repository.findAll(specification, pageable);
+    }
+
     public void publishEvent(Event event) {
         for (EventEndpoint endpoint : eventEndpoints) {
             endpoint.publishEvent(event);
         }
     }
 
-    public void incrementReadCount(Iterable<Event> events, String system) {
+    public void incrementReadCountForSystem(Iterable<Event> events, String system) {
         for (Event event : events) {
-            incrementReadCount(event, system);
+            incrementReadCountForSystem(event, system);
         }
     }
 
-    public Event incrementReadCount(Event event, String system) {
+    public Event incrementReadCountForSystem(Event event, String system) {
 
-        if (null == system) {
-            system = Event.DEFAULT_SYSTEM;
-        }
-
-        EventMetadata md = event.findMetadataForSystem(system);
-        if (md == null) {
-            md = new EventMetadata();
-            md.setNumTimesRead(1);
-            md.setStatus(Event.READ_STATUS);
-            md.setSystem(system);
-            event.getEventMetadata().add(md);
-        } else {
-            md.setNumTimesRead(md.getNumTimesRead() + 1);
-            md.setStatus(Event.READ_STATUS);
-            md.setSystem(system);
+        for (EventMetadata eventMetadata : event.getEventMetadata()) {
+            if (null == system || eventMetadata.getSystem().equals(system)) {
+                eventMetadata.setNumTimesRead(eventMetadata.getNumTimesRead() + 1);
+                eventMetadata.setStatus(Event.READ_STATUS);
+            }
         }
 
         return repository.save(event);

--- a/src/main/java/org/openhds/service/impl/EventService.java
+++ b/src/main/java/org/openhds/service/impl/EventService.java
@@ -1,0 +1,35 @@
+package org.openhds.service.impl;
+
+import org.openhds.events.endpoint.EventEndpoint;
+import org.openhds.events.model.Event;
+import org.openhds.repository.concrete.EventRepository;
+import org.openhds.service.contract.AbstractAuditableService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+/**
+ * Created by bsh on 6/30/15.
+ */
+public class EventService extends AbstractAuditableService <Event, EventRepository> {
+
+    @Autowired
+    public EventService(EventRepository repository) {
+        super(repository);
+    }
+
+    @Autowired
+    private List<EventEndpoint> eventEndpoints;
+
+    @Override
+    protected Event makeUnknownEntity() {
+        return new Event();
+    }
+
+    public void publishEvent(Event event) {
+        for (EventEndpoint endpoint : eventEndpoints) {
+            endpoint.publishEvent(event);
+        }
+    }
+
+}

--- a/src/test/java/org/openhds/resource/controller/ErrorLogRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/ErrorLogRestControllerTest.java
@@ -137,8 +137,8 @@ public class ErrorLogRestControllerTest extends AuditableCollectedRestController
                 .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(1)));
     }
 
-    private ErrorLog insertFancyAndReturn(String id,
-                                          String name,
+    private ErrorLog insertFancyAndReturn(String name,
+                                          String id,
                                           String resolutionStatus,
                                           String assignedTo,
                                           String entityType) throws Exception {

--- a/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
@@ -104,6 +104,51 @@ public class EventRestControllerTest extends AuditableRestControllerTest
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[*].actionType").value(everyItem(is("action-1"))))
                 .andExpect(jsonPath("$[*].uuid").value(contains("A-id", "C-id")));
+
+        // should see B and C for entity-2
+        this.mockMvc.perform(get(getResourceUrl() + "query")
+                .param("entityType", "entity-2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].entityType").value(everyItem(is("entity-2"))))
+                .andExpect(jsonPath("$[*].uuid").value(contains("B-id", "C-id")));
+
+        // should see A action-1 entity-1
+        this.mockMvc.perform(get(getResourceUrl() + "query")
+                .param("actionType", "action-1")
+                .param("entityType", "entity-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].actionType").value("action-1"))
+                .andExpect(jsonPath("$[0].entityType").value("entity-1"))
+                .andExpect(jsonPath("$[0].uuid").value("A-id"));
+
+        // should see B action-2 entity-2
+        this.mockMvc.perform(get(getResourceUrl() + "query")
+                .param("actionType", "action-2")
+                .param("entityType", "entity-2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].actionType").value("action-2"))
+                .andExpect(jsonPath("$[0].entityType").value("entity-2"))
+                .andExpect(jsonPath("$[0].uuid").value("B-id"));
+
+        // should see C for action-1 entity-2
+        this.mockMvc.perform(get(getResourceUrl() + "query")
+                .param("actionType", "action-1")
+                .param("entityType", "entity-2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].actionType").value("action-1"))
+                .andExpect(jsonPath("$[0].entityType").value("entity-2"))
+                .andExpect(jsonPath("$[0].uuid").value("C-id"));
+
+        // should see nothing for action-1 entity-1
+        this.mockMvc.perform(get(getResourceUrl() + "query")
+                .param("actionType", "action-2")
+                .param("entityType", "entity-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
     }
 
 

--- a/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
@@ -90,6 +90,28 @@ public class EventRestControllerTest extends AuditableRestControllerTest
 
     @Test
     @WithMockUser(username = username, password = password)
+    public void queryBulk() throws Exception {
+        Event event = postFancyAndReturn("test", "test-id", "test-action", "test-entity");
+        for (EventMetadata eventMetadata : event.getEventMetadata()) {
+            assertEquals(0, eventMetadata.getNumTimesRead());
+        }
+
+        // query with no params should return all events
+        final int totalCount = (int) repository.count();
+        this.mockMvc.perform(get(getResourceUrl() + "query/bulk")
+                .accept(regularJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(totalCount)))
+                .andExpect(jsonPath("$[*].eventMetadata[*].numTimesRead").value(everyItem(is(1))));
+
+        this.mockMvc.perform(get(getResourceUrl() + "query/bulk"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(totalCount)))
+                .andExpect(jsonPath("$[*].eventMetadata[*].numTimesRead").value(everyItem(is(2))));
+    }
+
+    @Test
+    @WithMockUser(username = username, password = password)
     public void queryByParameterValues() throws Exception {
         postFancyAndReturn("A", "A-id", "action-1", "entity-1");
         postFancyAndReturn("B", "B-id", "action-2", "entity-2");

--- a/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
@@ -1,0 +1,161 @@
+package org.openhds.resource.controller;
+
+import org.junit.Test;
+import org.openhds.errors.model.Error;
+import org.openhds.errors.model.ErrorLog;
+import org.openhds.events.model.Event;
+import org.openhds.events.model.EventMetadata;
+import org.openhds.repository.concrete.ErrorLogRepository;
+import org.openhds.repository.concrete.EventRepository;
+import org.openhds.repository.concrete.FieldWorkerRepository;
+import org.openhds.resource.contract.AuditableCollectedRestControllerTest;
+import org.openhds.resource.contract.AuditableRestControllerTest;
+import org.openhds.resource.registration.ErrorLogRegistration;
+import org.openhds.resource.registration.EventRegistration;
+import org.openhds.resource.registration.Registration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Created by bsh on 6/29/15.
+ */
+public class EventRestControllerTest extends AuditableRestControllerTest
+        <Event, EventRepository, EventRestController> {
+
+    @Autowired
+    @Override
+    protected void initialize(EventRepository repository, EventRestController controller) {
+        this.repository = repository;
+        this.controller = controller;
+    }
+
+    @Override
+    protected Event makeValidEntity(String name, String id) {
+        Event event = new Event();
+        event.setUuid(id);
+        event.setEventData(name);
+
+        EventMetadata eventMetadata = new EventMetadata();
+        eventMetadata.setSystem(name);
+        event.getEventMetadata().add(eventMetadata);
+
+        return event;
+    }
+
+    @Override
+    protected Event makeInvalidEntity() {
+        return new Event();
+    }
+
+    @Override
+    protected void verifyEntityExistsWithNameAndId(Event entity, String name, String id) {
+        assertNotNull(entity);
+
+        Event savedEvent = repository.findOne(id);
+        assertNotNull(savedEvent);
+
+        assertEquals(id, savedEvent.getUuid());
+        assertEquals(id, entity.getUuid());
+        assertEquals(entity.getEventData(), savedEvent.getEventData());
+    }
+
+    @Override
+    protected Registration<Event> makeRegistration(Event entity) {
+        EventRegistration eventRegistration = new EventRegistration();
+        eventRegistration.setEvent(entity);
+        return eventRegistration;
+    }
+
+//    @Test
+//    @WithMockUser(username = username, password = password)
+//    public void query() throws Exception {
+//        ErrorLog first = insertFancyAndReturn("first", "first-id", "first-status", "first-assigned", "first-entity");
+//        ErrorLog second = insertFancyAndReturn("second", "second-id", "second-status", "second-assigned", "second-entity");
+//        ErrorLog third = insertFancyAndReturn("third", "third-id", "third-status", "third-assigned", "third-entity");
+//
+//        // trivial query matches all
+//        final int totalCount = (int) repository.count();
+//        this.mockMvc.perform(get(getResourceUrl() + "query"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(totalCount)));
+//
+//        // several queries to match only the second
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("resolutionStatus", second.getResolutionStatus()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(1)));
+//
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("entityType", second.getEntityType()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(1)));
+//
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("assignedTo", second.getAssignedTo()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(1)));
+//
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("fieldWorkerId", second.getCollectedBy().getFieldWorkerId()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(totalCount)));
+//
+//        // queries by date range
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("minDate", second.getInsertDate().toString()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(2)));
+//
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("maxDate", second.getInsertDate().toString()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(totalCount - 1)));
+//
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("minDate", first.getInsertDate().toString())
+//                .param("maxDate", third.getInsertDate().toString()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(3)));
+//
+//        // match only the second, emphatically!
+//        this.mockMvc.perform(get(getResourceUrl() + "query")
+//                .param("resolutionStatus", second.getResolutionStatus())
+//                .param("assignedTo", second.getAssignedTo())
+//                .param("entityType", second.getEntityType())
+//                .param("fieldWorkerId", second.getCollectedBy().getFieldWorkerId())
+//                .param("minDate", second.getInsertDate().toString())
+//                .param("maxDate", second.getInsertDate().toString()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(1)));
+//    }
+
+//    private ErrorLog insertFancyAndReturn(String id,
+//                                          String name,
+//                                          String resolutionStatus,
+//                                          String assignedTo,
+//                                          String entityType) throws Exception {
+//
+//        ErrorLog errorLog = makeValidEntity(name, id);
+//        errorLog.setResolutionStatus(resolutionStatus);
+//        errorLog.setAssignedTo(assignedTo);
+//        errorLog.setEntityType(entityType);
+//
+//        MvcResult mvcResult = this.mockMvc.perform(post(getResourceUrl())
+//                .contentType(regularJson)
+//                .content(toJson(makeRegistration(errorLog))))
+//                .andExpect(status().isCreated())
+//                .andReturn();
+//
+//        ErrorLog created = fromJson(ErrorLog.class, mvcResult.getResponse().getContentAsString());
+//        return created;
+//    }
+}

--- a/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/EventRestControllerTest.java
@@ -1,29 +1,25 @@
 package org.openhds.resource.controller;
 
 import org.junit.Test;
-import org.openhds.errors.model.Error;
-import org.openhds.errors.model.ErrorLog;
 import org.openhds.events.model.Event;
 import org.openhds.events.model.EventMetadata;
-import org.openhds.repository.concrete.ErrorLogRepository;
 import org.openhds.repository.concrete.EventRepository;
-import org.openhds.repository.concrete.FieldWorkerRepository;
-import org.openhds.resource.contract.AuditableCollectedRestControllerTest;
 import org.openhds.resource.contract.AuditableRestControllerTest;
-import org.openhds.resource.registration.ErrorLogRegistration;
 import org.openhds.resource.registration.EventRegistration;
 import org.openhds.resource.registration.Registration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 /**
  * Created by bsh on 6/29/15.
@@ -42,11 +38,9 @@ public class EventRestControllerTest extends AuditableRestControllerTest
     protected Event makeValidEntity(String name, String id) {
         Event event = new Event();
         event.setUuid(id);
+        event.setEntityType(name);
+        event.setActionType(name);
         event.setEventData(name);
-
-        EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.setSystem(name);
-        event.getEventMetadata().add(eventMetadata);
 
         return event;
     }
@@ -75,12 +69,50 @@ public class EventRestControllerTest extends AuditableRestControllerTest
         return eventRegistration;
     }
 
+    @Test
+    @WithMockUser(username = username, password = password)
+    public void queryIncrementsReadCount() throws Exception {
+        Event event = postFancyAndReturn("test", "test-id", "test-action", "test-entity");
+        for (EventMetadata eventMetadata : event.getEventMetadata()) {
+            assertEquals(0, eventMetadata.getNumTimesRead());
+        }
+
+        // query with no params should return all events
+        final int totalCount = (int) repository.count();
+        this.mockMvc.perform(get(getResourceUrl() + "query"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(totalCount)))
+                .andExpect(jsonPath("$[*].eventMetadata[*].numTimesRead").value(everyItem(is(1))));
+
+        this.mockMvc.perform(get(getResourceUrl() + "query"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(totalCount)))
+                .andExpect(jsonPath("$[*].eventMetadata[*].numTimesRead").value(everyItem(is(2))));
+    }
+
+    @Test
+    @WithMockUser(username = username, password = password)
+    public void queryByParameterValues() throws Exception {
+        postFancyAndReturn("A", "A-id", "action-1", "entity-1");
+        postFancyAndReturn("B", "B-id", "action-2", "entity-2");
+        postFancyAndReturn("C", "C-id", "action-1", "entity-2");
+
+        // should see A and C for action-1
+        this.mockMvc.perform(get(getResourceUrl() + "query")
+                .param("actionType", "action-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].actionType").value(everyItem(is("action-1"))))
+                .andExpect(jsonPath("$[*].uuid").value(contains("A-id", "C-id")));
+    }
+
+
 //    @Test
 //    @WithMockUser(username = username, password = password)
 //    public void query() throws Exception {
-//        ErrorLog first = insertFancyAndReturn("first", "first-id", "first-status", "first-assigned", "first-entity");
-//        ErrorLog second = insertFancyAndReturn("second", "second-id", "second-status", "second-assigned", "second-entity");
-//        ErrorLog third = insertFancyAndReturn("third", "third-id", "third-status", "third-assigned", "third-entity");
+//        ErrorLog first = postFancyAndReturn("first", "first-id", "first-status", "first-assigned", "first-entity");
+//        ErrorLog second = postFancyAndReturn("second", "second-id", "second-status", "second-assigned", "second-entity");
+//        ErrorLog third = postFancyAndReturn("third", "third-id", "third-status", "third-assigned", "third-entity");
 //
 //        // trivial query matches all
 //        final int totalCount = (int) repository.count();
@@ -138,24 +170,22 @@ public class EventRestControllerTest extends AuditableRestControllerTest
 //                .andExpect(jsonPath("$._embedded." + controller.getResourceName(), hasSize(1)));
 //    }
 
-//    private ErrorLog insertFancyAndReturn(String id,
-//                                          String name,
-//                                          String resolutionStatus,
-//                                          String assignedTo,
-//                                          String entityType) throws Exception {
-//
-//        ErrorLog errorLog = makeValidEntity(name, id);
-//        errorLog.setResolutionStatus(resolutionStatus);
-//        errorLog.setAssignedTo(assignedTo);
-//        errorLog.setEntityType(entityType);
-//
-//        MvcResult mvcResult = this.mockMvc.perform(post(getResourceUrl())
-//                .contentType(regularJson)
-//                .content(toJson(makeRegistration(errorLog))))
-//                .andExpect(status().isCreated())
-//                .andReturn();
-//
-//        ErrorLog created = fromJson(ErrorLog.class, mvcResult.getResponse().getContentAsString());
-//        return created;
-//    }
+    private Event postFancyAndReturn(String name,
+                                     String id,
+                                     String actionType,
+                                     String entityType) throws Exception {
+
+        Event event = makeValidEntity(name, id);
+        event.setEntityType(entityType);
+        event.setActionType(actionType);
+
+        MvcResult mvcResult = this.mockMvc.perform(post(getResourceUrl())
+                .contentType(regularJson)
+                .content(toJson(makeRegistration(event))))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Event created = fromJson(Event.class, mvcResult.getResponse().getContentAsString());
+        return created;
+    }
 }


### PR DESCRIPTION
Adds event model, service, and REST resource for OpenHDS events which can be queried by external systems.

Required some fancy new JPA Criteria Queries for Events and EventMetadata.

GET queries for events have side-effects on associated metadata.  This may need to be revisited for performance and correctness of paged queries.
