### PR TITLE
added a UserDetailsWrapper and annotated or fixed broken tests

### DIFF
--- a/src/main/java/org/openhds/OpenHdsRestApplication.java
+++ b/src/main/java/org/openhds/OpenHdsRestApplication.java
@@ -11,7 +11,6 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;

--- a/src/main/java/org/openhds/domain/model/FieldWorker.java
+++ b/src/main/java/org/openhds/domain/model/FieldWorker.java
@@ -1,7 +1,6 @@
 package org.openhds.domain.model;
 
 import org.openhds.domain.contract.AuditableEntity;
-import org.openhds.domain.contract.ExtIdIdentifiable;
 import org.openhds.domain.util.Description;
 
 import javax.persistence.Entity;

--- a/src/main/java/org/openhds/domain/model/LocationHierarchy.java
+++ b/src/main/java/org/openhds/domain/model/LocationHierarchy.java
@@ -1,8 +1,6 @@
 package org.openhds.domain.model;
 
-import org.openhds.domain.contract.AuditableCollectedEntity;
 import org.openhds.domain.contract.AuditableExtIdEntity;
-import org.openhds.domain.contract.ExtIdIdentifiable;
 import org.openhds.domain.util.Description;
 
 import javax.persistence.CascadeType;

--- a/src/main/java/org/openhds/errors/model/ErrorLog.java
+++ b/src/main/java/org/openhds/errors/model/ErrorLog.java
@@ -7,7 +7,6 @@ import javax.persistence.*;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 
 @Description(description = "A log entry containing multiple errors.")

--- a/src/main/java/org/openhds/errors/util/ErrorLogUtil.java
+++ b/src/main/java/org/openhds/errors/util/ErrorLogUtil.java
@@ -6,7 +6,6 @@ import org.openhds.errors.model.ErrorLog;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 
 public class ErrorLogUtil {

--- a/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
+++ b/src/main/java/org/openhds/repository/util/SampleDataGenerator.java
@@ -6,8 +6,8 @@ import org.openhds.domain.model.FieldWorker;
 import org.openhds.domain.model.Location;
 import org.openhds.domain.model.LocationHierarchy;
 import org.openhds.domain.model.LocationHierarchyLevel;
-import org.openhds.errors.model.ErrorLog;
 import org.openhds.errors.model.Error;
+import org.openhds.errors.model.ErrorLog;
 import org.openhds.repository.concrete.*;
 import org.openhds.security.model.Privilege;
 import org.openhds.security.model.Role;
@@ -69,6 +69,7 @@ public class SampleDataGenerator {
         userRepository.deleteAllInBatch();
         roleRepository.deleteAllInBatch();
         privilegeRepository.deleteAllInBatch();
+
     }
 
     public void generateSampleData() {
@@ -77,8 +78,12 @@ public class SampleDataGenerator {
         addRole("user-role", Privilege.Grant.values());
         addUser("user", "password", "user-role");
 
+
         addRole("empty-role");
         addUser("non-user", "password", "empty-role");
+
+
+
 
         addFieldWorker("fieldworker", "password");
 
@@ -118,6 +123,7 @@ public class SampleDataGenerator {
 
     private void addUser(String name, String password, String roleName) {
         User user = new User();
+        user.setUuid(name);
         user.setFirstName(name);
         user.setLastName(name);
         user.setUsername(name);

--- a/src/main/java/org/openhds/resource/controller/ErrorLogRestController.java
+++ b/src/main/java/org/openhds/resource/controller/ErrorLogRestController.java
@@ -1,7 +1,7 @@
 package org.openhds.resource.controller;
 
 import org.openhds.domain.model.FieldWorker;
-import org.openhds.errors.model.*;
+import org.openhds.errors.model.ErrorLog;
 import org.openhds.repository.concrete.ErrorLogRepository;
 import org.openhds.repository.concrete.UserRepository;
 import org.openhds.repository.queries.QueryRange;

--- a/src/main/java/org/openhds/security/WebSecurityConfiguration.java
+++ b/src/main/java/org/openhds/security/WebSecurityConfiguration.java
@@ -1,6 +1,7 @@
 package org.openhds.security;
 
 import org.openhds.repository.concrete.UserRepository;
+import org.openhds.security.model.UserDetailsWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +11,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
@@ -40,11 +39,7 @@ public class WebSecurityConfiguration {
         @Bean
         public UserDetailsService userDetailsService() {
             return (username) -> userRepository.findByUsername(username)
-                    .map((org.openhds.security.model.User u) -> new User(
-                            u.getUsername(),
-                            u.getPassword(),
-                            true, true, true, true,
-                            AuthorityUtils.createAuthorityList(u.getPrivilegeNames().toArray(new String[0]))))
+                    .map((org.openhds.security.model.User u) -> new UserDetailsWrapper(u))
                     .orElseThrow(() -> new UsernameNotFoundException("No such user: " + username));
         }
     }

--- a/src/main/java/org/openhds/security/model/UserDetailsWrapper.java
+++ b/src/main/java/org/openhds/security/model/UserDetailsWrapper.java
@@ -1,0 +1,58 @@
+package org.openhds.security.model;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+/**
+ * Created by Wolfe on 7/6/2015.
+ */
+public class UserDetailsWrapper implements UserDetails{
+
+    private final User user;
+
+    public UserDetailsWrapper(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return AuthorityUtils.createAuthorityList(user.getPrivilegeNames().toArray(new String[0]));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    public User getUser(){
+        return user;
+    }
+}

--- a/src/main/java/org/openhds/service/contract/AbstractUuidService.java
+++ b/src/main/java/org/openhds/service/contract/AbstractUuidService.java
@@ -3,7 +3,6 @@ package org.openhds.service.contract;
 import org.openhds.domain.contract.UuidIdentifiable;
 import org.openhds.errors.model.Error;
 import org.openhds.errors.model.ErrorLog;
-import org.openhds.errors.model.ErrorLogException;
 import org.openhds.errors.util.ErrorLogger;
 import org.openhds.repository.contract.UuidIdentifiableRepository;
 import org.openhds.repository.queries.QueryRange;

--- a/src/test/java/org/openhds/OpenHdsRestApplicationTests.java
+++ b/src/test/java/org/openhds/OpenHdsRestApplicationTests.java
@@ -2,9 +2,9 @@ package org.openhds;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = OpenHdsRestApplication.class)

--- a/src/test/java/org/openhds/resource/contract/AuditableExtIdRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/contract/AuditableExtIdRestControllerTest.java
@@ -3,7 +3,7 @@ package org.openhds.resource.contract;
 import org.junit.Test;
 import org.openhds.domain.contract.AuditableExtIdEntity;
 import org.openhds.repository.contract.AuditableExtIdRepository;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,7 +22,7 @@ public abstract class AuditableExtIdRestControllerTest<T extends AuditableExtIdE
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getExternalValid() throws Exception {
         T entity = findAnyExisting();
         mockMvc.perform(get(getExternalResourceUrl() + entity.getExtId()))
@@ -32,7 +32,7 @@ public abstract class AuditableExtIdRestControllerTest<T extends AuditableExtIdE
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getExternalInvalid() throws Exception {
         mockMvc.perform(get(getExternalResourceUrl() + "invalid id"))
                 .andExpect(status().isNotFound());

--- a/src/test/java/org/openhds/resource/contract/AuditableRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/contract/AuditableRestControllerTest.java
@@ -3,7 +3,7 @@ package org.openhds.resource.contract;
 import org.junit.Test;
 import org.openhds.domain.contract.AuditableEntity;
 import org.openhds.repository.contract.AuditableRepository;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.ZonedDateTime;
@@ -35,7 +35,7 @@ public abstract class AuditableRestControllerTest<T extends AuditableEntity,
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getByDate() throws Exception {
 
         ZonedDateTime beforeDate = ZonedDateTime.now();
@@ -113,7 +113,7 @@ public abstract class AuditableRestControllerTest<T extends AuditableEntity,
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getVoided() throws Exception {
         // make one
         T entity = insertNewAndReturn();

--- a/src/test/java/org/openhds/resource/contract/UuidIdentifiableRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/contract/UuidIdentifiableRestControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.http.MockHttpInputMessage;
 import org.springframework.mock.http.MockHttpOutputMessage;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.io.IOException;
@@ -100,7 +101,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     // POST
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void postNewJson() throws Exception {
         T entity = makeValidEntity("test registration", "test id");
 
@@ -115,7 +116,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void postNewXml() throws Exception {
         T entity = makeValidEntity("test registration", "test id");
 
@@ -131,7 +132,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void postUpdate() throws Exception {
         T entity = makeUpdateEntity("test update");
 
@@ -146,7 +147,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void postInvalid() throws Exception {
         this.mockMvc.perform(post(getResourceUrl())
                 .contentType(regularJson)
@@ -157,7 +158,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     // PUT
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void putNew() throws Exception {
         final String uuid = UUID.randomUUID().toString();
         T entity = makeValidEntity("test registration", "ignored id");
@@ -173,7 +174,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void putNewXml() throws Exception {
         final String uuid = UUID.randomUUID().toString();
         T entity = makeValidEntity("test registration", "ignored id");
@@ -190,7 +191,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void putUpdate() throws Exception {
         T entity = makeUpdateEntity("test update");
 
@@ -205,7 +206,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void putInvalid() throws Exception {
         final String uuid = UUID.randomUUID().toString();
 
@@ -218,7 +219,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     // GET
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getSingleValid() throws Exception {
         T entity = findAnyExisting();
         mockMvc.perform(get(getResourceUrl() + entity.getUuid())
@@ -229,7 +230,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getSingleValidXml() throws Exception {
         T entity = findAnyExisting();
         mockMvc.perform(get(getResourceUrl() + entity.getUuid())
@@ -240,14 +241,14 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getSingleInvalid() throws Exception {
         mockMvc.perform(get(getResourceUrl() + "invalid id"))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getAll() throws Exception {
         mockMvc.perform(get(getResourceUrl()))
                 .andExpect(status().isOk())
@@ -256,7 +257,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getPaged() throws Exception {
         // get the first page of size 1
         mockMvc.perform(get(getResourceUrl())
@@ -271,7 +272,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getBulkJson() throws Exception {
         mockMvc.perform(get(getResourceUrl() + "/bulk")
                 .param("sort", "uuid")
@@ -282,7 +283,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void getBulkXml() throws Exception {
         mockMvc.perform(get(getResourceUrl() + "/bulk")
                 .param("sort", "uuid")
@@ -295,14 +296,14 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     // DELETE
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void deleteCollection() throws Exception {
         mockMvc.perform(delete(getResourceUrl()))
                 .andExpect(status().isMethodNotAllowed());
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void deleteInvalid() throws Exception {
         final String invalidId = "not an id";
         mockMvc.perform(delete(getResourceUrl() + invalidId))
@@ -310,7 +311,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void deleteExisting() throws Exception {
         T entity = findAnyExisting();
         MvcResult mvcResult = mockMvc.perform(delete(getResourceUrl() + entity.getUuid()))
@@ -320,7 +321,7 @@ public abstract class UuidIdentifiableRestControllerTest<T extends UuidIdentifia
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void deleteNew() throws Exception {
         T entity = makeValidEntity("delete me", "test id");
         this.mockMvc.perform(post(getResourceUrl())

--- a/src/test/java/org/openhds/resource/controller/ErrorLogRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/ErrorLogRestControllerTest.java
@@ -9,7 +9,7 @@ import org.openhds.resource.contract.AuditableCollectedRestControllerTest;
 import org.openhds.resource.registration.ErrorLogRegistration;
 import org.openhds.resource.registration.Registration;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.ZonedDateTime;
@@ -79,7 +79,7 @@ public class ErrorLogRestControllerTest extends AuditableCollectedRestController
     }
 
     @Test
-    @WithMockUser(username = username, password = password)
+    @WithUserDetails
     public void query() throws Exception {
         ErrorLog first = insertFancyAndReturn("first", "first-id", "first-status", "first-assigned", "first-entity");
         ErrorLog second = insertFancyAndReturn("second", "second-id", "second-status", "second-assigned", "second-entity");

--- a/src/test/java/org/openhds/resource/controller/RestControllerTestSupport.java
+++ b/src/test/java/org/openhds/resource/controller/RestControllerTestSupport.java
@@ -1,7 +1,9 @@
 package org.openhds.resource.controller;
 
 import com.jayway.jsonpath.JsonPath;
+
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openhds.OpenHdsRestApplication;
@@ -97,7 +99,13 @@ public class RestControllerTestSupport {
         assertNotNull("the Json message converter must not be null", jsonMessageConverter);
         assertNotNull("the Xml message converter must not be null", xmlMessageConverter);
 
+    }
 
+
+    @After
+    public void tearDown() {
+        sampleDataGenerator.clearData();
+        sampleDataGenerator.generateSampleData();
     }
 
     @Test

--- a/src/test/java/org/openhds/resource/controller/UserRestControllerTest.java
+++ b/src/test/java/org/openhds/resource/controller/UserRestControllerTest.java
@@ -1,5 +1,6 @@
 package org.openhds.resource.controller;
 
+import org.junit.After;
 import org.openhds.repository.concrete.UserRepository;
 import org.openhds.resource.contract.UuidIdentifiableRestControllerTest;
 import org.openhds.resource.registration.Registration;
@@ -56,5 +57,6 @@ public class UserRestControllerTest extends UuidIdentifiableRestControllerTest<U
         registration.setUser(entity);
         return registration;
     }
+
 
 }

--- a/src/test/java/org/openhds/service/AuditableCollectedServiceTest.java
+++ b/src/test/java/org/openhds/service/AuditableCollectedServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.openhds.domain.contract.AuditableCollectedEntity;
 import org.openhds.domain.model.FieldWorker;
 import org.openhds.service.contract.AbstractAuditableCollectedService;
+import org.springframework.security.test.context.support.WithUserDetails;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -24,6 +25,7 @@ public abstract class AuditableCollectedServiceTest
      */
 
     @Test
+    @WithUserDetails
     public void findByCollectedBy() {
 
         T entity = makeValidEntity("testEntity", "testEntity");
@@ -44,26 +46,23 @@ public abstract class AuditableCollectedServiceTest
      */
 
     @Test
+    @WithUserDetails
     public void findByCollectionDateTime() {
 
-        ZonedDateTime earlyTime = ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]");
-        ZonedDateTime lateTime = ZonedDateTime.parse("2008-12-03T10:15:30+01:00[Europe/Paris]");
-
         T earlyEntity = makeValidEntity("earlyEntity", "earlyEntity");
-        earlyEntity.setCollectionDateTime(earlyTime);
+        ZonedDateTime earlyTime = service.createOrUpdate(earlyEntity).getCollectionDateTime();
+
         T lateEntity = makeValidEntity("lateEntity", "lateEntity");
-        lateEntity.setCollectionDateTime(lateTime);
+        ZonedDateTime lateTime = service.createOrUpdate(lateEntity).getCollectionDateTime();
 
-        service.createOrUpdate(earlyEntity);
-        service.createOrUpdate(lateEntity);
 
-        List<T> betweenReslts = service.findByCollectionDateTime(null, earlyTime, lateTime).toList();
+        List<T> betweenReslts = service.findByCollectionDateTime(UUID_SORT, earlyTime, lateTime).toList();
         assertEquals(betweenReslts.size(), 2);
 
-        List<T> afterReslts = service.findByCollectionDateTime(null, earlyTime, null).toList();
+        List<T> afterReslts = service.findByCollectionDateTime(UUID_SORT, earlyTime, null).toList();
         assertNotEquals(afterReslts.size(), 0);
 
-        List<T> beforeReslts = service.findByCollectionDateTime(null, null, lateTime).toList();
+        List<T> beforeReslts = service.findByCollectionDateTime(UUID_SORT, null, lateTime).toList();
         assertNotEquals(beforeReslts.size(), 0);
     }
 }

--- a/src/test/java/org/openhds/service/AuditableExtIdServiceTest.java
+++ b/src/test/java/org/openhds/service/AuditableExtIdServiceTest.java
@@ -3,6 +3,7 @@ package org.openhds.service;
 import org.junit.Test;
 import org.openhds.domain.contract.AuditableExtIdEntity;
 import org.openhds.service.contract.AbstractAuditableExtIdService;
+import org.springframework.security.test.context.support.WithUserDetails;
 
 import static org.junit.Assert.assertEquals;
 
@@ -18,6 +19,7 @@ public abstract class AuditableExtIdServiceTest
      */
 
     @Test
+    @WithUserDetails
     public void findByExtId() {
 
         String id = "testEntity";

--- a/src/test/java/org/openhds/service/AuditableServiceTest.java
+++ b/src/test/java/org/openhds/service/AuditableServiceTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import org.openhds.domain.contract.AuditableEntity;
 import org.openhds.security.model.User;
 import org.openhds.service.contract.AbstractAuditableService;
-import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithUserDetails;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -19,8 +19,6 @@ public abstract class AuditableServiceTest
         <T extends AuditableEntity, U extends AbstractAuditableService<T, ?>>
         extends UuidServiceTest<T, U> {
 
-    private static final Sort UUID_SORT = new Sort("uuid");
-
     /**
      * Simply check that results are not null after a findAll call
      */
@@ -33,8 +31,8 @@ public abstract class AuditableServiceTest
     }
 
 
-
     @Test
+    @WithUserDetails
     public void update() {
 
         String id = "testId";
@@ -57,18 +55,15 @@ public abstract class AuditableServiceTest
      */
 
     @Test
+    @WithUserDetails
     public void findByInsertDate() {
 
-        ZonedDateTime earlyTime = ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]");
-        ZonedDateTime lateTime = ZonedDateTime.parse("2008-12-03T10:15:30+01:00[Europe/Paris]");
-
         T earlyEntity = makeValidEntity("earlyEntity", "earlyEntity");
-        earlyEntity.setInsertDate(earlyTime);
-        T lateEntity = makeValidEntity("lateEntity", "lateEntity");
-        lateEntity.setInsertDate(lateTime);
+        ZonedDateTime earlyTime = service.createOrUpdate(earlyEntity).getInsertDate();
 
-        service.createOrUpdate(earlyEntity);
-        service.createOrUpdate(lateEntity);
+        T lateEntity = makeValidEntity("lateEntity", "lateEntity");
+        ZonedDateTime lateTime = service.createOrUpdate(lateEntity).getInsertDate();
+
 
         List<T> betweenReslts = service.findByInsertDate(UUID_SORT, earlyTime, lateTime).toList();
         assertEquals(betweenReslts.size(), 2);
@@ -82,18 +77,15 @@ public abstract class AuditableServiceTest
     }
 
     @Test
+    @WithUserDetails
     public void findByLastModifiedDate() {
 
-        ZonedDateTime earlyTime = ZonedDateTime.parse("2007-12-03T10:15:30+01:00[Europe/Paris]");
-        ZonedDateTime lateTime = ZonedDateTime.parse("2008-12-03T10:15:30+01:00[Europe/Paris]");
-
         T earlyEntity = makeValidEntity("earlyEntity", "earlyEntity");
-        earlyEntity.setLastModifiedDate(earlyTime);
-        T lateEntity = makeValidEntity("lateEntity", "lateEntity");
-        lateEntity.setLastModifiedDate(lateTime);
+        ZonedDateTime earlyTime = service.createOrUpdate(earlyEntity).getLastModifiedDate();
 
-        service.createOrUpdate(earlyEntity);
-        service.createOrUpdate(lateEntity);
+        T lateEntity = makeValidEntity("lateEntity", "lateEntity");
+        ZonedDateTime lateTime = service.createOrUpdate(lateEntity).getLastModifiedDate();
+
 
         List<T> betweenReslts = service.findByLastModifiedDate(UUID_SORT, earlyTime, lateTime).toList();
         assertEquals(betweenReslts.size(), 2);
@@ -107,6 +99,7 @@ public abstract class AuditableServiceTest
     }
 
     @Test
+    @WithUserDetails
     public void delete() {
 
         int entityCount = service.findAll(UUID_SORT).toList().size();
@@ -125,28 +118,28 @@ public abstract class AuditableServiceTest
     }
 
     @Test
+    @WithUserDetails
     public void findByInsertBy() {
 
         T entity = makeValidEntity("testEntity", "testEntity");
-        User user = entity.getInsertBy();
+        User user = service.createOrUpdate(entity).getInsertBy();
 
         int entityCount = service.findByInsertBy(UUID_SORT, user).toList().size();
-
-        service.createOrUpdate(entity);
+        service.createOrUpdate(makeValidEntity("anotherTestEntity", "anotherTestEntity"));
 
         assertEquals(service.findByInsertBy(UUID_SORT, user).toList().size(), entityCount + 1);
 
     }
 
     @Test
+    @WithUserDetails
     public void findByLastModifiedBy() {
 
         T entity = makeValidEntity("testEntity", "testEntity");
-        User user = entity.getLastModifiedBy();
+        User user = service.createOrUpdate(entity).getLastModifiedBy();
 
         int entityCount = service.findByLastModifiedBy(UUID_SORT, user).toList().size();
-
-        service.createOrUpdate(entity);
+        service.createOrUpdate(makeValidEntity("anotherTestEntity", "anotherTestEntity"));
 
         assertEquals(service.findByLastModifiedBy(UUID_SORT, user).toList().size(), entityCount + 1);
 

--- a/src/test/java/org/openhds/service/UuidServiceTest.java
+++ b/src/test/java/org/openhds/service/UuidServiceTest.java
@@ -1,5 +1,6 @@
 package org.openhds.service;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,6 +13,7 @@ import org.openhds.service.contract.AbstractUuidService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
@@ -56,8 +58,14 @@ public abstract class UuidServiceTest<T extends UuidIdentifiable, U extends Abst
         sampleDataGenerator.generateSampleData();
     }
 
+    @After
+    public void tearDown() {
+        sampleDataGenerator.clearData();
+        sampleDataGenerator.generateSampleData();
+    }
 
     @Test
+    @WithUserDetails
     public void create() {
 
         int beforeCreationSize = service.findAll(null).toList().size();

--- a/src/test/java/org/openhds/service/impl/LocationServiceTest.java
+++ b/src/test/java/org/openhds/service/impl/LocationServiceTest.java
@@ -3,7 +3,6 @@ package org.openhds.service.impl;
 
 import org.openhds.domain.model.Location;
 import org.openhds.service.AuditableExtIdServiceTest;
-import org.openhds.service.impl.LocationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.ZonedDateTime;


### PR DESCRIPTION
Added a UserDetailsWrapper that acts a middle man between the Spring User model and the OpenHDS User model.

This is used in the AuditableService to add insertBy and modifiedBy information into entities.

This pull request also includes a lot of test fixes that were broken by this implementation.
