### PR TITLE
Added toString to all domain entities and supertypes

### DIFF
--- a/src/main/java/org/openhds/domain/contract/AuditableCollectedEntity.java
+++ b/src/main/java/org/openhds/domain/contract/AuditableCollectedEntity.java
@@ -65,4 +65,13 @@ public abstract class AuditableCollectedEntity extends AuditableEntity implement
     public void setStatusMessage(String statusMessage) {
         this.statusMessage = statusMessage;
     }
+
+    @Override
+    public String toString() {
+        return "AuditableCollectedEntity{" +
+                "status='" + status + '\'' +
+                ", collectionDateTime=" + collectionDateTime +
+                ", statusMessage='" + statusMessage + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/domain/contract/AuditableEntity.java
+++ b/src/main/java/org/openhds/domain/contract/AuditableEntity.java
@@ -156,4 +156,15 @@ public abstract class AuditableEntity implements UuidIdentifiable, Serializable 
         return true;
     }
 
+    @Override
+    public String toString() {
+        return "AuditableEntity{" +
+                "uuid='" + uuid + '\'' +
+                ", deleted=" + deleted +
+                ", voidReason='" + voidReason + '\'' +
+                ", voidDate=" + voidDate +
+                ", insertDate=" + insertDate +
+                ", lastModifiedDate=" + lastModifiedDate +
+                '}';
+    }
 }

--- a/src/main/java/org/openhds/domain/contract/AuditableExtIdEntity.java
+++ b/src/main/java/org/openhds/domain/contract/AuditableExtIdEntity.java
@@ -29,4 +29,11 @@ public abstract class AuditableExtIdEntity extends AuditableCollectedEntity impl
     public void setExtId(String extId) {
         this.extId = extId;
     }
+
+    @Override
+    public String toString() {
+        return "AuditableExtIdEntity{" +
+                "extId='" + extId + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/domain/model/FieldWorker.java
+++ b/src/main/java/org/openhds/domain/model/FieldWorker.java
@@ -99,4 +99,15 @@ public class FieldWorker extends AuditableEntity implements Serializable {
         return null != uuid && null != otherUuid && uuid.equals(otherUuid);
     }
 
+    @Override
+    public String toString() {
+        return "FieldWorker{" +
+                "fieldWorkerId='" + fieldWorkerId + '\'' +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", password='" + password + '\'' +
+                ", passwordHash='" + passwordHash + '\'' +
+                ", idPrefix=" + idPrefix +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/domain/model/Location.java
+++ b/src/main/java/org/openhds/domain/model/Location.java
@@ -260,4 +260,29 @@ public class Location extends AuditableExtIdEntity implements Serializable {
         final String otherUuid = ((Location) other).getUuid();
         return null != uuid && null != otherUuid && uuid.equals(otherUuid);
     }
+
+    @Override
+    public String toString() {
+        return "Location{" +
+                "name='" + name + '\'' +
+                ", locationHierarchy=" + locationHierarchy +
+                ", type='" + type + '\'' +
+                ", longitude='" + longitude + '\'' +
+                ", latitude='" + latitude + '\'' +
+                ", accuracy='" + accuracy + '\'' +
+                ", altitude='" + altitude + '\'' +
+                ", buildingNumber='" + buildingNumber + '\'' +
+                ", floorNumber='" + floorNumber + '\'' +
+                ", regionName='" + regionName + '\'' +
+                ", provinceName='" + provinceName + '\'' +
+                ", subDistrictName='" + subDistrictName + '\'' +
+                ", districtName='" + districtName + '\'' +
+                ", sectorName='" + sectorName + '\'' +
+                ", localityName='" + localityName + '\'' +
+                ", communityName='" + communityName + '\'' +
+                ", communityCode='" + communityCode + '\'' +
+                ", mapAreaName='" + mapAreaName + '\'' +
+                ", description='" + description + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/domain/model/LocationHierarchy.java
+++ b/src/main/java/org/openhds/domain/model/LocationHierarchy.java
@@ -85,4 +85,12 @@ public class LocationHierarchy extends AuditableExtIdEntity implements Serializa
         return null != uuid && null != otherUuid && uuid.equals(otherUuid);
     }
 
+    @Override
+    public String toString() {
+        return "LocationHierarchy{" +
+                "parent=" + parent +
+                ", name='" + name + '\'' +
+                ", level=" + level +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/domain/model/LocationHierarchyLevel.java
+++ b/src/main/java/org/openhds/domain/model/LocationHierarchyLevel.java
@@ -37,4 +37,12 @@ public class LocationHierarchyLevel extends AuditableEntity implements Serializa
     public void setName(String name) {
         this.name = name;
     }
+
+    @Override
+    public String toString() {
+        return "LocationHierarchyLevel{" +
+                "keyIdentifier=" + keyIdentifier +
+                ", name='" + name + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/errors/model/ErrorLog.java
+++ b/src/main/java/org/openhds/errors/model/ErrorLog.java
@@ -107,4 +107,16 @@ public class ErrorLog extends AuditableCollectedEntity implements Serializable {
 
         return stringBuilder.toString();
     }
+
+    @Override
+    public String toString() {
+        return "ErrorLog{" +
+                "dataPayload='" + dataPayload + '\'' +
+                ", errors=" + errors +
+                ", assignedTo='" + assignedTo + '\'' +
+                ", entityType='" + entityType + '\'' +
+                ", resolutionStatus='" + resolutionStatus + '\'' +
+                ", dateOfResolution=" + dateOfResolution +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/events/model/Event.java
+++ b/src/main/java/org/openhds/events/model/Event.java
@@ -91,4 +91,14 @@ public class Event extends AuditableEntity implements Serializable {
 
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                "actionType='" + actionType + '\'' +
+                ", entityType='" + entityType + '\'' +
+                ", eventData='" + eventData + '\'' +
+                ", eventMetadata=" + eventMetadata +
+                "} " + super.toString();
+    }
 }

--- a/src/main/java/org/openhds/security/model/User.java
+++ b/src/main/java/org/openhds/security/model/User.java
@@ -146,4 +146,18 @@ public class User implements Serializable, UuidIdentifiable {
                 .map(Privilege::toString)
                 .collect(toSet());
     }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "uuid='" + uuid + '\'' +
+                ", firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", description='" + description + '\'' +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                ", roles=" + roles +
+                ", deleted=" + deleted +
+                '}';
+    }
 }

--- a/src/main/java/org/openhds/service/contract/AbstractUuidService.java
+++ b/src/main/java/org/openhds/service/contract/AbstractUuidService.java
@@ -112,7 +112,7 @@ public abstract class AbstractUuidService<T extends UuidIdentifiable, V extends 
             Event event = new Event();
             event.setActionType(Event.PERSIST_ACTION);
             event.setEntityType(entity.getClass().getSimpleName());
-            event.setEventData("UUID: "+entity.getUuid()+" "+entity.toString());
+            event.setEventData(entity.toString());
             eventPublisher.publish(event);
         }
 


### PR DESCRIPTION
This is so the payload added to event's is actually useful.

Strings for fields that are lazy loaded are not included in the payload to avoid LazyInitializationException.
