### PR TITLE
Complex Registration Service Methods

### DIFF
--- a/src/main/java/org/openhds/domain/model/census/Individual.java
+++ b/src/main/java/org/openhds/domain/model/census/Individual.java
@@ -3,6 +3,8 @@ package org.openhds.domain.model.census;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.openhds.domain.contract.AuditableExtIdEntity;
 import org.openhds.domain.model.update.Death;
+import org.openhds.domain.model.update.PregnancyObservation;
+import org.openhds.domain.model.update.PregnancyOutcome;
 import org.openhds.domain.util.Description;
 
 import javax.persistence.*;
@@ -74,6 +76,16 @@ public class Individual extends AuditableExtIdEntity implements Serializable {
     @OneToOne(mappedBy = "individual")
     @Description(description = "The death registered for this individual.")
     private Death death;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "mother")
+    @Description(description = "The set of all pregnancyObservations that have this individual as the mother.")
+    private Set<PregnancyObservation> pregnancyObservations = new HashSet<>();
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "mother")
+    @Description(description = "The set of all pregnancyOutcomes that have this individual as the mother.")
+    private Set<PregnancyOutcome> pregnancyOutcomes = new HashSet<>();
 
     public String getFirstName() {
         return firstName;
@@ -163,6 +175,19 @@ public class Individual extends AuditableExtIdEntity implements Serializable {
         this.relationshipsAsIndividualB = relationshipsAsIndividualB;
     }
 
+    public Set<PregnancyObservation> getPregnancyObservations() {
+        return pregnancyObservations;
+    }
+    public void setPregnancyObservations(Set<PregnancyObservation> pregnancyObservations) {
+        this.pregnancyObservations = pregnancyObservations;
+    }
+
+    public Set<PregnancyOutcome> getPregnancyOutcomes() {
+        return pregnancyOutcomes;
+    }
+    public void setPregnancyOutcomes(Set<PregnancyOutcome> pregnancyOutcomes) {
+        this.pregnancyOutcomes = pregnancyOutcomes;
+    }
     public Set<Residency> collectActiveResidencies(Set<Residency> collectedResidencies) {
         if (null == collectedResidencies) {
             return null;

--- a/src/main/java/org/openhds/domain/model/census/Individual.java
+++ b/src/main/java/org/openhds/domain/model/census/Individual.java
@@ -205,4 +205,15 @@ public class Individual extends AuditableExtIdEntity implements Serializable {
         return false;
     }
 
+    public boolean hasOpenMembership(){
+        if (null != memberships) {
+            for (Membership existingMembership : memberships) {
+                if(null == existingMembership.getEndDate()){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/org/openhds/resource/controller/update/DeathRestController.java
+++ b/src/main/java/org/openhds/resource/controller/update/DeathRestController.java
@@ -47,6 +47,7 @@ public class DeathRestController extends AuditableCollectedRestController<
     @Override
     protected Death register(DeathRegistration registration) {
         return deathService.recordDeath(registration.getDeath(),
+                registration.getRegistrationDateTime(),
                 registration.getIndividualUuid(),
                 registration.getVisitUuid(),
                 registration.getCollectedByUuid());

--- a/src/main/java/org/openhds/resource/controller/update/DeathRestController.java
+++ b/src/main/java/org/openhds/resource/controller/update/DeathRestController.java
@@ -47,7 +47,6 @@ public class DeathRestController extends AuditableCollectedRestController<
     @Override
     protected Death register(DeathRegistration registration) {
         return deathService.recordDeath(registration.getDeath(),
-                registration.getRegistrationDateTime(),
                 registration.getIndividualUuid(),
                 registration.getVisitUuid(),
                 registration.getCollectedByUuid());

--- a/src/main/java/org/openhds/service/impl/census/IndividualService.java
+++ b/src/main/java/org/openhds/service/impl/census/IndividualService.java
@@ -69,29 +69,29 @@ public class IndividualService extends AbstractAuditableExtIdService<Individual,
     public Individual recordIndividual(Individual individual,
                                        ZonedDateTime recordTime,
                                        String relationToHead,
-                                       String headOfHouseholdUuid,
-                                       String relationshipUuid,
-                                       String locationUuid,
-                                       String socialGroupUuid,
-                                       String fieldWorkerUuid,
-                                       String motherUuid,
-                                       String fatherUuid,
-                                       String membershipUuid,
-                                       String residencyUuid){
+                                       String headOfHouseholdId,
+                                       String relationshipId,
+                                       String locationId,
+                                       String socialGroupId,
+                                       String fieldWorkerId,
+                                       String motherId,
+                                       String fatherId,
+                                       String membershipId,
+                                       String residencyId){
 
         String startType = "individualRegistration";
 
-        FieldWorker collectedBy = fieldWorkerService.findOrMakePlaceHolder(fieldWorkerUuid);
+        FieldWorker collectedBy = fieldWorkerService.findOrMakePlaceHolder(fieldWorkerId);
         ZonedDateTime collectionDateTime = individual.getCollectionDateTime();
 
-        individual.setMother(findOrMakePlaceHolder(motherUuid));
-        individual.setFather(findOrMakePlaceHolder(fatherUuid));
+        individual.setMother(findOrMakePlaceHolder(motherId));
+        individual.setFather(findOrMakePlaceHolder(fatherId));
         individual.setCollectedBy(collectedBy);
         individual.setStatusMessage(individual.NORMAL_STATUS);
         individual = createOrUpdate(individual);
 
-        Relationship relationship = relationshipService.findOrMakePlaceHolder(relationshipUuid);
-        Individual headOfHousehold = findOrMakePlaceHolder(headOfHouseholdUuid);
+        Relationship relationship = relationshipService.findOrMakePlaceHolder(relationshipId);
+        Individual headOfHousehold = findOrMakePlaceHolder(headOfHouseholdId);
         relationship.setIndividualA(individual);
         relationship.setIndividualB(headOfHousehold);
         relationship.setRelationshipType(relationToHead);
@@ -101,9 +101,9 @@ public class IndividualService extends AbstractAuditableExtIdService<Individual,
         relationship.setEntityStatus(relationship.NORMAL_STATUS);
         relationshipService.createOrUpdate(relationship);
 
-        Membership membership = membershipService.findOrMakePlaceHolder(membershipUuid);
+        Membership membership = membershipService.findOrMakePlaceHolder(membershipId);
         membership.setIndividual(individual);
-        membership.setSocialGroup(socialGroupService.findOrMakePlaceHolder(socialGroupUuid));
+        membership.setSocialGroup(socialGroupService.findOrMakePlaceHolder(socialGroupId));
         membership.setStartType(startType);
         membership.setStartDate(recordTime);
         membership.setEntityStatus(membership.NORMAL_STATUS);
@@ -111,9 +111,9 @@ public class IndividualService extends AbstractAuditableExtIdService<Individual,
         membership.setCollectionDateTime(collectionDateTime);
         membershipService.createOrUpdate(membership);
 
-        Residency residency = residencyService.makePlaceHolder(residencyUuid);
+        Residency residency = residencyService.makePlaceHolder(residencyId);
         residency.setIndividual(individual);
-        residency.setLocation(locationService.findOrMakePlaceHolder(locationUuid));
+        residency.setLocation(locationService.findOrMakePlaceHolder(locationId));
         residency.setCollectedBy(collectedBy);
         residency.setCollectionDateTime(collectionDateTime);
         residency.setStartType(startType);

--- a/src/main/java/org/openhds/service/impl/census/IndividualService.java
+++ b/src/main/java/org/openhds/service/impl/census/IndividualService.java
@@ -1,9 +1,8 @@
 package org.openhds.service.impl.census;
 
+import org.openhds.domain.model.FieldWorker;
 import org.openhds.domain.model.ProjectCode;
-import org.openhds.domain.model.census.Individual;
-import org.openhds.domain.model.census.LocationHierarchy;
-import org.openhds.domain.model.census.Residency;
+import org.openhds.domain.model.census.*;
 import org.openhds.errors.model.ErrorLog;
 import org.openhds.repository.concrete.census.IndividualRepository;
 import org.openhds.service.contract.AbstractAuditableExtIdService;
@@ -13,8 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import javax.management.relation.Relation;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Subquery;
+import java.lang.reflect.Field;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -28,6 +29,17 @@ public class IndividualService extends AbstractAuditableExtIdService<Individual,
 
     @Autowired
     private LocationHierarchyService locationHierarchyService;
+    @Autowired
+    private RelationshipService relationshipService;
+    @Autowired
+    private ResidencyService residencyService;
+    @Autowired
+    private MembershipService membershipService;
+    @Autowired
+    private SocialGroupService socialGroupService;
+    @Autowired
+    private LocationService locationService;
+
 
     @Autowired
     public IndividualService(IndividualRepository repository) {
@@ -52,6 +64,64 @@ public class IndividualService extends AbstractAuditableExtIdService<Individual,
         individual.setCollectedBy(fieldWorkerService.findOrMakePlaceHolder(fieldWorkerId));
         individual.setEntityStatus(individual.NORMAL_STATUS);
         return createOrUpdate(individual);
+    }
+
+    public Individual recordIndividual(Individual individual,
+                                       ZonedDateTime recordTime,
+                                       String relationToHead,
+                                       String headOfHouseholdUuid,
+                                       String relationshipUuid,
+                                       String locationUuid,
+                                       String socialGroupUuid,
+                                       String fieldWorkerUuid,
+                                       String motherUuid,
+                                       String fatherUuid,
+                                       String membershipUuid,
+                                       String residencyUuid){
+
+        String startType = "individualRegistration";
+
+        FieldWorker collectedBy = fieldWorkerService.findOrMakePlaceHolder(fieldWorkerUuid);
+        ZonedDateTime collectionDateTime = individual.getCollectionDateTime();
+
+        individual.setMother(findOrMakePlaceHolder(motherUuid));
+        individual.setFather(findOrMakePlaceHolder(fatherUuid));
+        individual.setCollectedBy(collectedBy);
+        individual.setStatusMessage(individual.NORMAL_STATUS);
+        individual = createOrUpdate(individual);
+
+        Relationship relationship = relationshipService.findOrMakePlaceHolder(relationshipUuid);
+        Individual headOfHousehold = findOrMakePlaceHolder(headOfHouseholdUuid);
+        relationship.setIndividualA(individual);
+        relationship.setIndividualB(headOfHousehold);
+        relationship.setRelationshipType(relationToHead);
+        relationship.setCollectedBy(collectedBy);
+        relationship.setCollectionDateTime(collectionDateTime);
+        relationship.setStartDate(recordTime);
+        relationship.setEntityStatus(relationship.NORMAL_STATUS);
+        relationshipService.createOrUpdate(relationship);
+
+        Membership membership = membershipService.findOrMakePlaceHolder(membershipUuid);
+        membership.setIndividual(individual);
+        membership.setSocialGroup(socialGroupService.findOrMakePlaceHolder(socialGroupUuid));
+        membership.setStartType(startType);
+        membership.setStartDate(recordTime);
+        membership.setEntityStatus(membership.NORMAL_STATUS);
+        membership.setCollectedBy(collectedBy);
+        membership.setCollectionDateTime(collectionDateTime);
+        membershipService.createOrUpdate(membership);
+
+        Residency residency = residencyService.makePlaceHolder(residencyUuid);
+        residency.setIndividual(individual);
+        residency.setLocation(locationService.findOrMakePlaceHolder(locationUuid));
+        residency.setCollectedBy(collectedBy);
+        residency.setCollectionDateTime(collectionDateTime);
+        residency.setStartType(startType);
+        residency.setStartDate(recordTime);
+        residency.setEntityStatus(residency.NORMAL_STATUS);
+        residencyService.createOrUpdate(residency);
+
+        return individual;
     }
 
     @Override

--- a/src/main/java/org/openhds/service/impl/update/DeathService.java
+++ b/src/main/java/org/openhds/service/impl/update/DeathService.java
@@ -59,7 +59,7 @@ public class DeathService extends AbstractAuditableCollectedService<Death, Death
         return death;
     }
 
-    public Death recordDeath(Death death, ZonedDateTime recordTime, String individualId, String visitId, String fieldWorkerId){
+    public Death recordDeath(Death death, String individualId, String visitId, String fieldWorkerId){
         death.setIndividual(individualService.findOrMakePlaceHolder(individualId));
         death.setVisit(visitService.findOrMakePlaceHolder(visitId));
         death.setCollectedBy(fieldWorkerService.findOrMakePlaceHolder(fieldWorkerId));
@@ -101,19 +101,19 @@ public class DeathService extends AbstractAuditableCollectedService<Death, Death
             }
 
             for(Membership membership : deadIndividual.getMemberships()){
-              membership.setEndDate(recordTime);
+              membership.setEndDate(persistedDeath.getDeathDate());
               membership.setEndType(endType);
             }
             for(Relationship relationship : deadIndividual.getRelationshipsAsIndividualA()){
-              relationship.setEndDate(recordTime);
+              relationship.setEndDate(persistedDeath.getDeathDate());
               relationship.setEndType(endType);
             }
             for(Relationship relationship : deadIndividual.getRelationshipsAsIndividualB()){
-              relationship.setEndDate(recordTime);
+              relationship.setEndDate(persistedDeath.getDeathDate());
               relationship.setEndType(endType);
             }
             for(Residency residency : deadIndividual.getResidencies()){
-              residency.setEndDate(recordTime);
+              residency.setEndDate(persistedDeath.getDeathDate());
               residency.setEndType(endType);
             }
 

--- a/src/main/java/org/openhds/service/impl/update/InMigrationService.java
+++ b/src/main/java/org/openhds/service/impl/update/InMigrationService.java
@@ -3,6 +3,7 @@ package org.openhds.service.impl.update;
 import org.openhds.domain.contract.AuditableEntity;
 import org.openhds.domain.model.ProjectCode;
 import org.openhds.domain.model.census.LocationHierarchy;
+import org.openhds.domain.model.census.Residency;
 import org.openhds.domain.model.update.InMigration;
 import org.openhds.errors.model.ErrorLog;
 import org.openhds.repository.concrete.update.InMigationRepository;
@@ -67,7 +68,18 @@ public class InMigrationService extends AbstractAuditableCollectedService<InMigr
         inMigration.setVisit(visitService.findOrMakePlaceHolder(visitId));
         inMigration.setCollectedBy(fieldWorkerService.findOrMakePlaceHolder(fieldWorkerId));
         inMigration.setEntityStatus(inMigration.NORMAL_STATUS);
-        return createOrUpdate(inMigration);
+
+        InMigration persistedInMigration = createOrUpdate(inMigration);
+
+        Residency residency = persistedInMigration.getResidency();
+        residency.setEntityStatus(residency.NORMAL_STATUS);
+        residency.setStartDate(inMigration.getMigrationDate());
+        residency.setStartType("inMigration");
+        residency.setCollectedBy(inMigration.getCollectedBy());
+        residency.setCollectionDateTime(inMigration.getCollectionDateTime());
+        residencyService.createOrUpdate(residency);
+
+        return persistedInMigration;
     }
 
     @Override

--- a/src/main/java/org/openhds/service/impl/update/OutMigrationService.java
+++ b/src/main/java/org/openhds/service/impl/update/OutMigrationService.java
@@ -2,6 +2,7 @@ package org.openhds.service.impl.update;
 
 import org.openhds.domain.contract.AuditableEntity;
 import org.openhds.domain.model.census.LocationHierarchy;
+import org.openhds.domain.model.census.Residency;
 import org.openhds.domain.model.update.OutMigration;
 import org.openhds.errors.model.ErrorLog;
 import org.openhds.repository.concrete.update.OutMigationRepository;
@@ -65,7 +66,17 @@ public class OutMigrationService extends AbstractAuditableCollectedService<OutMi
         outMigration.setVisit(visitService.findOrMakePlaceHolder(visitId));
         outMigration.setCollectedBy(fieldWorkerService.findOrMakePlaceHolder(fieldWorkerId));
         outMigration.setEntityStatus(outMigration.NORMAL_STATUS);
-        return createOrUpdate(outMigration);
+
+        OutMigration persistedOutMigration = createOrUpdate(outMigration);
+      
+        Residency residency = persistedOutMigration.getResidency();
+            if(residency.getEntityStatus().equals(residency.NORMAL_STATUS)){
+                residency.setEndType("outMigration");
+                residency.setEndDate(persistedOutMigration.getMigrationDate());
+                residencyService.createOrUpdate(residency);
+            }
+
+        return persistedOutMigration;
     }
 
     @Override

--- a/src/main/java/org/openhds/service/impl/update/PregnancyResultService.java
+++ b/src/main/java/org/openhds/service/impl/update/PregnancyResultService.java
@@ -114,6 +114,7 @@ public class PregnancyResultService extends AbstractAuditableCollectedService<Pr
             child.setMother(mother);
             individualService.createOrUpdate(child);
 
+            // make residency same as mom's
             if(mother.getEntityStatus().equals(Individual.NORMAL_STATUS)){
                 for(Residency residency : mother.getResidencies()){
                     if(null != residency.getEndDate()){
@@ -131,6 +132,7 @@ public class PregnancyResultService extends AbstractAuditableCollectedService<Pr
                     }
                 }
 
+                //make membership same as mom's
                 for(Membership membership : mother.getMemberships()){
                     if(null != membership.getEndDate()){
                         Membership childMembership = new Membership();

--- a/src/test/java/org/openhds/service/AuditableCollectedServiceTest.java
+++ b/src/test/java/org/openhds/service/AuditableCollectedServiceTest.java
@@ -20,6 +20,14 @@ public abstract class AuditableCollectedServiceTest
         <T extends AuditableCollectedEntity, U extends AbstractAuditableCollectedService<T, ?>>
         extends AuditableServiceTest<T, U> {
 
+    public static final String FIELDWORKER_ID = "feldwarker";
+    public static final String SOCIALGROUP_ID = "suculgrup";
+    public static final String LOCATION_ID = "lucutun";
+    public static final String INDIVIDUAL_ID = "induuvudu";
+    public static final String RELATIONSHIP_ID = "relutuup";
+    public static final String RESIDENCY_ID = "rsususndy";
+    public static final String MEMBERSHIP_ID = "mumburshub";
+    public static final String PREGNANCY_OUTCOME_ID = "prugnuncy_ootkoom";
 
     @Autowired
     protected FieldWorkerService fieldWorkerService;

--- a/src/test/java/org/openhds/service/impl/census/IndividualServiceTest.java
+++ b/src/test/java/org/openhds/service/impl/census/IndividualServiceTest.java
@@ -18,14 +18,6 @@ import static org.junit.Assert.assertNotNull;
  */
 public class IndividualServiceTest extends AuditableExtIdServiceTest<Individual, IndividualService> {
 
-    public static final String FIELDWORKER_ID = "feldwarker";
-    public static final String SOCIALGROUP_ID = "suculgrup";
-    public static final String LOCATION_ID = "lucutun";
-    public static final String INDIVIDUAL_ID = "induuvudu";
-    public static final String RELATIONSHIP_ID = "relutuup";
-    public static final String RESIDENCY_ID = "rsususndy";
-    public static final String MEMBERSHIP_ID = "mumburshub";
-
     @Autowired
     private LocationHierarchyService locationHierarchyService;
     @Autowired
@@ -93,7 +85,6 @@ public class IndividualServiceTest extends AuditableExtIdServiceTest<Individual,
 
         Individual fancyIndividual = makeValidEntity("FancyMan", "FancyId");
         String relationshipType = projectCodeService.findByCodeGroup(ProjectCode.RELATIONSHIP_TYPE).get(0).getCodeValue();
-        ZonedDateTime collectionDateTime = ZonedDateTime.now().plusHours(1);
         ZonedDateTime recordTime = ZonedDateTime.now().minusHours(1);
 
         service.recordIndividual(fancyIndividual,

--- a/src/test/java/org/openhds/service/impl/census/IndividualServiceTest.java
+++ b/src/test/java/org/openhds/service/impl/census/IndividualServiceTest.java
@@ -2,9 +2,13 @@ package org.openhds.service.impl.census;
 
 import org.junit.Test;
 import org.openhds.domain.model.FieldWorker;
+import org.openhds.domain.model.ProjectCode;
 import org.openhds.domain.model.census.Individual;
 import org.openhds.service.AuditableExtIdServiceTest;
+import org.openhds.service.impl.ProjectCodeService;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.ZonedDateTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -15,6 +19,28 @@ import static org.junit.Assert.assertNotNull;
 public class IndividualServiceTest extends AuditableExtIdServiceTest<Individual, IndividualService> {
 
     public static final String FIELDWORKER_ID = "feldwarker";
+    public static final String SOCIALGROUP_ID = "suculgrup";
+    public static final String LOCATION_ID = "lucutun";
+    public static final String INDIVIDUAL_ID = "induuvudu";
+    public static final String RELATIONSHIP_ID = "relutuup";
+    public static final String RESIDENCY_ID = "rsususndy";
+    public static final String MEMBERSHIP_ID = "mumburshub";
+
+    @Autowired
+    private LocationHierarchyService locationHierarchyService;
+    @Autowired
+    private RelationshipService relationshipService;
+    @Autowired
+    private ResidencyService residencyService;
+    @Autowired
+    private MembershipService membershipService;
+    @Autowired
+    private SocialGroupService socialGroupService;
+    @Autowired
+    private LocationService locationService;
+    @Autowired
+    private ProjectCodeService projectCodeService;
+
 
     @Override
     protected Individual makeInvalidEntity() {
@@ -59,6 +85,35 @@ public class IndividualServiceTest extends AuditableExtIdServiceTest<Individual,
         //check that they were persisted
         assertNotNull(individual.getCollectedBy());
         assertEquals(individual.getCollectedBy().getUuid(), FIELDWORKER_ID);
+
+    }
+
+    @Test
+    public void complexRecordValid(){
+
+        Individual fancyIndividual = makeValidEntity("FancyMan", "FancyId");
+        String relationshipType = projectCodeService.findByCodeGroup(ProjectCode.RELATIONSHIP_TYPE).get(0).getCodeValue();
+        ZonedDateTime collectionDateTime = ZonedDateTime.now().plusHours(1);
+        ZonedDateTime recordTime = ZonedDateTime.now().minusHours(1);
+
+        service.recordIndividual(fancyIndividual,
+            recordTime,
+            relationshipType,
+            INDIVIDUAL_ID,
+            RELATIONSHIP_ID,
+            LOCATION_ID,
+            SOCIALGROUP_ID,
+            FIELDWORKER_ID,
+            "jo",
+            "jill",
+            MEMBERSHIP_ID,
+            RESIDENCY_ID);
+
+        assertEquals(service.findOne(fancyIndividual.getUuid()), fancyIndividual);
+        assertEquals(membershipService.findOne(MEMBERSHIP_ID).getStartType(), "individualRegistration");
+        assertEquals(residencyService.findOne(RESIDENCY_ID).getStartType(), "individualRegistration");
+        assertEquals(relationshipService.findOne(RELATIONSHIP_ID).getRelationshipType(), relationshipType);
+
 
     }
 }

--- a/src/test/java/org/openhds/service/impl/update/DeathServiceTest.java
+++ b/src/test/java/org/openhds/service/impl/update/DeathServiceTest.java
@@ -9,6 +9,8 @@ import org.openhds.service.AuditableCollectedServiceTest;
 import org.openhds.service.impl.census.IndividualService;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.ZonedDateTime;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -50,7 +52,7 @@ public class DeathServiceTest extends AuditableCollectedServiceTest<Death, Death
         death.setIndividual(null);
 
         // pass it all into the record method
-        death = service.recordDeath(death, individual.getUuid(), visit.getUuid(), fieldWorker.getUuid());
+        death = service.recordDeath(death, ZonedDateTime.now(), individual.getUuid(), visit.getUuid(), fieldWorker.getUuid());
 
 
         //Check that the originals match the ones pulled out from findOrMakePlaceholder()
@@ -75,7 +77,7 @@ public class DeathServiceTest extends AuditableCollectedServiceTest<Death, Death
         death.setIndividual(null);
 
         //Pass it in with new reference uuids
-        death = service.recordDeath(death, "induvudual", "vusut", "feldwarker");
+        death = service.recordDeath(death, ZonedDateTime.now(), "induvudual", "vusut", "feldwarker");
 
         //check that they were persisted
         assertNotNull(death.getCollectedBy());

--- a/src/test/java/org/openhds/service/impl/update/DeathServiceTest.java
+++ b/src/test/java/org/openhds/service/impl/update/DeathServiceTest.java
@@ -52,7 +52,7 @@ public class DeathServiceTest extends AuditableCollectedServiceTest<Death, Death
         death.setIndividual(null);
 
         // pass it all into the record method
-        death = service.recordDeath(death, ZonedDateTime.now(), individual.getUuid(), visit.getUuid(), fieldWorker.getUuid());
+        death = service.recordDeath(death, individual.getUuid(), visit.getUuid(), fieldWorker.getUuid());
 
 
         //Check that the originals match the ones pulled out from findOrMakePlaceholder()
@@ -77,7 +77,7 @@ public class DeathServiceTest extends AuditableCollectedServiceTest<Death, Death
         death.setIndividual(null);
 
         //Pass it in with new reference uuids
-        death = service.recordDeath(death, ZonedDateTime.now(), "induvudual", "vusut", "feldwarker");
+        death = service.recordDeath(death, "induvudual", "vusut", "feldwarker");
 
         //check that they were persisted
         assertNotNull(death.getCollectedBy());

--- a/src/test/java/org/openhds/service/impl/update/PregnancyResultServiceTest.java
+++ b/src/test/java/org/openhds/service/impl/update/PregnancyResultServiceTest.java
@@ -9,6 +9,8 @@ import org.openhds.service.AuditableCollectedServiceTest;
 import org.openhds.service.impl.census.IndividualService;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.ZonedDateTime;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -119,6 +121,14 @@ public class PregnancyResultServiceTest extends AuditableCollectedServiceTest<Pr
         //cheggerout
         assertEquals(pregnancyResult.getPregnancyOutcome().getVoidReason(), "blegh");
 
+    }
+
+    @Test
+    public void complexRecordValid(){
+        PregnancyResult pregnancyResult = makeValidEntity("validName", "validId");
+        ZonedDateTime recordTime = ZonedDateTime.now().minusHours(1);
+
+        service.recordPregnancyResult(pregnancyResult, recordTime, PREGNANCY_OUTCOME_ID, INDIVIDUAL_ID, FIELDWORKER_ID, MEMBERSHIP_ID, RESIDENCY_ID);
     }
 
 }


### PR DESCRIPTION
There is a PR to easily see the diff and have a place to communicate.

A few things I noticed when making this:
- Probably want to log an event when the record methods are called, but maybe having them when entities are actually persisted is good enough.
- It feels like there are way too many params for the recordIndividual method but it's all information that the method needs in order to do the complex registration.
  - Should it accept a map instead?
  - Could it some how be broken into more than one action? (i.e. 2 record methods / 2 separate registrations some how?)
