### PR TITLE
adding actual origin to the cors response to play nice with the standard

### DIFF
--- a/src/main/java/org/openhds/security/WebSecurityConfiguration.java
+++ b/src/main/java/org/openhds/security/WebSecurityConfiguration.java
@@ -71,8 +71,7 @@ public class WebSecurityConfiguration {
                     HttpServletRequest request = (HttpServletRequest) servletRequest;
                     HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-                    // TODO: for now, allow all origins
-                    response.setHeader("Access-Control-Allow-Origin", "*");
+                    response.setHeader("Access-Control-Allow-Origin", ((HttpServletRequest) servletRequest).getHeader("Origin"));
 
                     // TODO: are these the verbs and headers we really want?
                     response.setHeader("Access-Control-Allow-Methods", "POST,GET,OPTIONS,DELETE");


### PR DESCRIPTION
I ran into the issue described below. It looks like you can't use Access-Control-Allow-Origin: '*' with authentication also. 

http://stackoverflow.com/questions/19743396/cors-cannot-use-wildcard-in-access-control-allow-origin-when-credentials-flag-i
