### PR TITLE
Default sample size

### DIFF
--- a/src/main/java/org/openhds/OpenHdsRestApplication.java
+++ b/src/main/java/org/openhds/OpenHdsRestApplication.java
@@ -49,8 +49,7 @@ public class OpenHdsRestApplication {
                                                 Environment environment) {
         return (args) -> {
             if (!environment.containsProperty(SAMPLE_DATA_SIZE_PROPERTY)) {
-                // start normally
-                // TODO: create default user on first time startup?
+            	masterDataGenerator.generateRequiredData();
                 return;
             }
 

--- a/src/main/java/org/openhds/repository/generator/MasterDataGenerator.java
+++ b/src/main/java/org/openhds/repository/generator/MasterDataGenerator.java
@@ -43,6 +43,11 @@ public class MasterDataGenerator implements DataGenerator {
         }
     }
 
+    public void generateRequiredData()	{
+    	DataGenerator dataGenerator = dataGenerators.get(0);
+    	dataGenerator.generateData();
+    }
+
     @Override
     public void generateData(int size) {
         log.info("Generating data with size " + size + ".");


### PR DESCRIPTION
When sampleDataSize was not included in the command line argument, the required data generator (which initializes the default user:password) was never called.

Added a method to the MasterDataGenerator that generates only the required data. It is called when no sampleDataSize is given. 
