### PR TITLE
Add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM java:8
+MAINTAINER munk <munk@protonmail.com>
+ADD . /service
+COPY build/libs/openhds-rest-0.0.1-SNAPSHOT.jar /service/openhds-rest.jar
+WORKDIR /service
+CMD ["java", "-jar", "openhds-rest.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM java:8
-MAINTAINER munk <munk@protonmail.com>
 ADD . /service
 COPY build/libs/openhds-rest-0.0.1-SNAPSHOT.jar /service/openhds-rest.jar
 WORKDIR /service


### PR DESCRIPTION
This allows the rest service to be built as a docker image. This enables deployment with docker compose as shown here https://github.com/munk/openhds
